### PR TITLE
Rename heads_up to guess_up and fix flash screen

### DIFF
--- a/.claude/claude-p2p-plan.md
+++ b/.claude/claude-p2p-plan.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The game is currently single-device only. The goal is to add a networked two-player mode where one person (Viewer) sees the word and gives verbal clues, while the other person (Holder) guesses and presses y/n — just like the real Heads Up game but across two terminals on different networks. A relay server running on the user's always-online server bridges the two clients. Players can switch roles between games within a session.
+The game is currently single-device only. The goal is to add a networked two-player mode where one person (Viewer) sees the word and gives verbal clues, while the other person (Holder) guesses and presses y/n — just like the real Guess Up game but across two terminals on different networks. A relay server running on the user's always-online server bridges the two clients. Players can switch roles between games within a session.
 
 ## Architecture Overview
 
@@ -26,7 +26,7 @@ The game is currently single-device only. The goal is to add a networked two-pla
 Convert the single crate into a workspace with three crates:
 
 ```
-Quick_HeadsUp/
+Guess-Up/
   Cargo.toml                  # workspace root
   files/ASOIAF_list.txt
   crates/
@@ -61,7 +61,7 @@ Move the existing single-package project into a workspace layout.
 - Existing `src/` moves to `crates/client/src/`
 - Existing dependencies move to `crates/client/Cargo.toml`
 - `files/` stays at the repo root; the client references it with a relative path (update default in clap arg)
-- Verify: `cargo build -p heads_up` and `cargo run -p heads_up` work identically to today
+- Verify: `cargo build -p guess_up` and `cargo run -p guess_up` work identically to today
 
 **Files modified:** `Cargo.toml` (rewrite), new `crates/client/Cargo.toml`, `crates/client/src/main.rs` (word file default path)
 
@@ -176,9 +176,9 @@ struct Room {
 Add clap subcommands. Default (no subcommand) runs solo mode for backwards compat.
 
 ```
-heads_up                                    # solo mode (existing behavior)
-heads_up host --relay addr:port             # create room, display code, wait for peer
-heads_up join --relay addr:port --code XXXX # join existing room
+guess_up                                    # solo mode (existing behavior)
+guess_up host --relay addr:port             # create room, display code, wait for peer
+guess_up join --relay addr:port --code XXXX # join existing room
 ```
 
 Game flags (`-g`, `-s`, `-l`, `-x`, `--bonus-seconds`, `-w`, `--category`) apply to solo and host modes. The joiner receives config from the host.
@@ -339,10 +339,10 @@ Existing `render_question`, `render_question_unlimited`, `flash_*`, `print_outpu
 
 | Step | What | Testable? |
 |------|-------|-----------|
-| 1 | Workspace restructure | `cargo run -p heads_up` works identically |
+| 1 | Workspace restructure | `cargo run -p guess_up` works identically |
 | 2 | Protocol crate | Unit tests for serialization round-trips |
 | 3 | Relay server | Manual test: two `nc` / test clients create + join rooms |
-| 4 | CLI subcommands | `heads_up host/join` parse args, connect to relay, show room code |
+| 4 | CLI subcommands | `guess_up host/join` parse args, connect to relay, show room code |
 | 5 | net.rs + types.rs | Two clients connect, see "peer joined" |
 | 6 | lobby.rs | Role selection works, both sides agree on roles |
 | 7 | Host game loop networking | Host plays full game, remote receives messages (not rendered yet) |
@@ -352,7 +352,7 @@ Existing `render_question`, `render_question_unlimited`, `flash_*`, `print_outpu
 
 ## Verification
 
-1. **Solo mode regression**: `cargo run -p heads_up` — all existing scenarios still work
+1. **Solo mode regression**: `cargo run -p guess_up` — all existing scenarios still work
 2. **Relay**: Start relay, verify room create/join with two terminals
 3. **Full networked game**: Host creates room, joiner enters code, roles assigned, play a full game, verify both sides show correct views
 4. **Role swap**: After game, swap roles, play again — verify views switch

--- a/.claude/claude-plan.md
+++ b/.claude/claude-plan.md
@@ -1,8 +1,8 @@
-# Heads Up CLI Game - Rewrite Plan
+# Guess Up CLI Game - Rewrite Plan
 
 ## Context
 
-The existing ASOIAF Heads Up game (`exercise-6/`) had a fundamentally broken async architecture: a custom `Future` impl with blocking `stdin().read_line()` inside `poll()`, which blocked the entire tokio runtime. The timer only fired after user input, giving the last question infinite time. The centering logic required pre-padded word list entries (leading spaces on odd-length names). Several features were abandoned mid-implementation (color flash). This rewrite fixes the architecture with channels + `tokio::select!`, adds game modes, and improves the UX.
+The existing ASOIAF Guess Up game (`exercise-6/`) had a fundamentally broken async architecture: a custom `Future` impl with blocking `stdin().read_line()` inside `poll()`, which blocked the entire tokio runtime. The timer only fired after user input, giving the last question infinite time. The centering logic required pre-padded word list entries (leading spaces on odd-length names). Several features were abandoned mid-implementation (color flash). This rewrite fixes the architecture with channels + `tokio::select!`, adds game modes, and improves the UX.
 
 ## Feature Status
 
@@ -18,7 +18,7 @@ The existing ASOIAF Heads Up game (`exercise-6/`) had a fundamentally broken asy
 - [x] **Live score + timer** -- updates every second via `TimerTick`, score shown alongside timer
 - [x] **Custom word list** -- `--word-file <path>` flag, default `files/ASOIAF_list.txt`
 - [x] **Category support** -- `[Category]` headers in word files, `--category <name>` flag to filter
-- [x] **Game history** -- saves results to `~/.heads_up_history.json` with serde
+- [x] **Game history** -- saves results to `~/.guess_up_history.json` with serde
 - [x] **Terminal bell** -- `\x07` on timer expiry
 - [x] **Terminal safety** -- `TerminalGuard` with `Drop` for raw mode + alternate screen cleanup
 - [x] **Fisher-Yates shuffle** -- O(n) word selection, graceful exhaustion handling
@@ -30,7 +30,7 @@ The existing ASOIAF Heads Up game (`exercise-6/`) had a fundamentally broken asy
 ### Not Yet Implemented
 
 - [ ] **Networked mode** -- two machines connected, one sees timer/scores, other sees names (long-term goal)
-- [ ] **Game history CLI viewer** -- no way to view `~/.heads_up_history.json` from the CLI yet
+- [ ] **Game history CLI viewer** -- no way to view `~/.guess_up_history.json` from the CLI yet
 - [ ] **Configurable key bindings** -- keys are hardcoded (y/n/q)
 - [ ] **Multi-round / replay** -- game exits after one round, no "play again?" prompt
 - [ ] **Sound effects beyond bell** -- only terminal bell on expiry, no per-answer sounds
@@ -118,7 +118,7 @@ Changes from v0.1:
 - Added `futures` for `StreamExt::next()` on `EventStream`
 - Added `serde` + `serde_json` for game history JSON serialization
 - Added `chrono` for timestamps in history entries
-- Added `dirs` for `home_dir()` to locate `~/.heads_up_history.json`
+- Added `dirs` for `home_dir()` to locate `~/.guess_up_history.json`
 - Removed `rascii_art` (countdown rewritten with box-drawing characters)
 - Removed `term_size` (crossterm provides `terminal::size()`)
 
@@ -139,6 +139,6 @@ The module split (`input.rs` separate from `game.rs`) specifically enables swapp
 3. `cargo run -- --last-unlimited` -- timer expires, shows "LAST QUESTION", waits for answer, then ends
 4. `cargo run -- --extra-time --bonus-seconds 3` -- correct answers add 3 seconds to timer
 5. `cargo run -- --word-file files/ASOIAF_list.txt --category "House Stark"` -- only Stark names appear
-6. Check `~/.heads_up_history.json` exists after a game
+6. Check `~/.guess_up_history.json` exists after a game
 7. Ctrl+C during game -- terminal restores cleanly (raw mode off, alternate screen exited)
 8. Run with very long names and very short names -- centering is correct for both

--- a/.claude/tui-menu-plan.md
+++ b/.claude/tui-menu-plan.md
@@ -8,7 +8,7 @@ The client currently uses clap to parse CLI args for all game settings and netwo
 
 | File | Purpose |
 |------|---------|
-| `crates/client/src/config.rs` | `AppConfig` struct, defaults, load/save `~/.heads_up_config.json`, `to_game_config()` |
+| `crates/client/src/config.rs` | `AppConfig` struct, defaults, load/save `~/.guess_up_config.json`, `to_game_config()` |
 | `crates/client/src/menu.rs` | Menu state machine, rendering, input handling, `menu_loop()` → `MenuAction` |
 
 ## Modified Files
@@ -21,7 +21,7 @@ The client currently uses clap to parse CLI args for all game settings and netwo
 | `Cargo.toml` | Remove `clap` dependency. |
 | No changes to: `types.rs`, `game.rs`, `input.rs`, `timer.rs`, `net.rs` |
 
-## Config File (`~/.heads_up_config.json`)
+## Config File (`~/.guess_up_config.json`)
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 ### Key Implementation Details
 
 - **TerminalGuard**: RAII pattern with `Drop` — ensures raw mode and alternate screen are cleaned up on panic or early exit.
-- **Flash race condition**: `flash_screen()` clobbers the display; after 150ms it sends `GameEvent::Redraw` so the game loop re-renders the current word.
+- **Flash race condition**: `flash_screen()` clobbers the display; after 300ms it sends `GameEvent::Redraw` so the game loop re-renders the current word. Both game loops track a `flashing` flag to skip renders while the flash is on screen, preventing the game loop or timer ticks from overwriting the flash effect.
 - **Summary rendering**: `TerminalGuard` must be dropped *before* `print_output()` — otherwise the summary prints inside the alternate screen buffer and gets wiped.
 - **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting.
 - **Host-authoritative model**: The host owns all game state (words, timer, score). The joiner runs `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput`, Holder processes `UserInput`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-An ASOIAF (A Song of Ice and Fire) themed "Heads Up" party game for the terminal, built in Rust. Players see a name/term on screen and press `y` (correct) or `n` (pass) before the timer runs out. Supports solo play and networked two-player mode via a relay server.
+An ASOIAF (A Song of Ice and Fire) themed "Guess Up" party game for the terminal, built in Rust. Players see a name/term on screen and press `y` (correct) or `n` (pass) before the timer runs out. Supports solo play and networked two-player mode via a relay server.
 
 ## Build & Run
 
 ```bash
 cargo build --release                          # build all crates
-cargo run -p heads_up                          # solo mode, default 60s game
-cargo run -p heads_up -- -x --bonus-seconds 3  # extra-time mode
-cargo run -p heads_up -- --category "House Stark"  # filter by category
+cargo run -p guess_up                          # solo mode, default 60s game
+cargo run -p guess_up -- -x --bonus-seconds 3  # extra-time mode
+cargo run -p guess_up -- --category "House Stark"  # filter by category
 
 # Networked mode
-cargo run -p heads_up -- host --relay server:7878
-cargo run -p heads_up -- join --relay server:7878 --code ABCDE
+cargo run -p guess_up -- host --relay server:7878
+cargo run -p guess_up -- join --relay server:7878 --code ABCDE
 
 # Relay server
 cargo run -p relay                             # binds to 0.0.0.0:7878
@@ -77,7 +77,7 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 - **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting.
 - **Host-authoritative model**: The host owns all game state (words, timer, score). The joiner runs `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput`, Holder processes `UserInput`.
 - **Word loading**: Parses `[Category]` headers, trims lines, deduplicates via `HashSet` (case-insensitive).
-- **History**: Saved to `~/.heads_up_history.json` via serde.
+- **History**: Saved to `~/.guess_up_history.json` via serde.
 
 ### Protocol
 
@@ -90,12 +90,12 @@ The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`
 
 Manual play-testing is the primary test strategy. Key scenarios to verify:
 
-1. `cargo run -p heads_up` — normal mode works end-to-end
-2. `cargo run -p heads_up -- --last-unlimited` — last question gets infinite time
-3. `cargo run -p heads_up -- --extra-time --bonus-seconds 3` — bonus time adds correctly
-4. `cargo run -p heads_up -- --category "House Stark"` — category filtering works
+1. `cargo run -p guess_up` — normal mode works end-to-end
+2. `cargo run -p guess_up -- --last-unlimited` — last question gets infinite time
+3. `cargo run -p guess_up -- --extra-time --bonus-seconds 3` — bonus time adds correctly
+4. `cargo run -p guess_up -- --category "House Stark"` — category filtering works
 5. Ctrl+C during game — terminal restores cleanly
-6. `~/.heads_up_history.json` is written after a game
+6. `~/.guess_up_history.json` is written after a game
 7. Networked mode: host + join, role selection, play-again flow, peer disconnect handling
 
 ## Working With Claude
@@ -123,7 +123,7 @@ Violating this rule means lost work, broken workflows, and angry maintainers. **
 
 ## Future Plans
 
-- **Game history CLI viewer**: View `~/.heads_up_history.json` from the command line.
+- **Game history CLI viewer**: View `~/.guess_up_history.json` from the command line.
 - **Multi-round / replay**: "Play again?" prompt after a solo round.
 - **Configurable key bindings**: Currently hardcoded to y/n/q.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 ### Key Implementation Details
 
 - **TerminalGuard**: RAII pattern with `Drop` — ensures raw mode and alternate screen are cleaned up on panic or early exit.
-- **Flash race condition**: `flash_screen()` clobbers the display; after 300ms it sends `GameEvent::Redraw` so the game loop re-renders the current word. Both game loops track a `flashing` flag to skip renders while the flash is on screen, preventing the game loop or timer ticks from overwriting the flash effect.
+- **Flash race condition**: `flash_screen()` clobbers the display; after 150ms it sends `GameEvent::Redraw` so the game loop re-renders the current word. Both game loops track a `flashing` flag to skip renders while the flash is on screen, preventing the game loop or timer ticks from overwriting the flash effect.
 - **Summary rendering**: `TerminalGuard` must be dropped *before* `print_output()` — otherwise the summary prints inside the alternate screen buffer and gets wiped.
 - **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting.
 - **Host-authoritative model**: The host owns all game state (words, timer, score). The joiner runs `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput`, Holder processes `UserInput`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Heads Up! - ASOIAF Edition
+# Guess Up! - ASOIAF Edition
 
-A terminal-based "Heads Up" party game themed around A Song of Ice and Fire. Play solo (hold the screen to your forehead while friends give clues) or networked (two players on different machines connected through a relay server).
+A terminal-based "Guess Up" party game themed around A Song of Ice and Fire. Play solo (hold the screen to your forehead while friends give clues) or networked (two players on different machines connected through a relay server).
 
 Press `y` for correct, `n` to pass — no Enter needed.
 
@@ -13,11 +13,11 @@ Requires [Rust](https://www.rust-lang.org/tools/install). If you run into versio
 cargo build --release
 
 # Play solo — default 60-second game
-cargo run -p heads_up
+cargo run -p guess_up
 
 # Or play networked (see sections below)
-cargo run -p heads_up -- host --relay your-server:7878
-cargo run -p heads_up -- join --relay your-server:7878 --code ABCDE
+cargo run -p guess_up -- host --relay your-server:7878
+cargo run -p guess_up -- join --relay your-server:7878 --code ABCDE
 ```
 
 Press `q` at any time to quit. The terminal always restores cleanly, even on Ctrl+C.
@@ -27,14 +27,14 @@ Press `q` at any time to quit. The terminal always restores cleanly, even on Ctr
 When you run without a subcommand, you get the original single-device experience:
 
 ```bash
-cargo run -p heads_up                              # default 60-second game
-cargo run -p heads_up -- -g 90                     # 90-second game
-cargo run -p heads_up -- -s                        # skip the 3-2-1 countdown
-cargo run -p heads_up -- -l                        # unlimited time on the last question
-cargo run -p heads_up -- -x                        # extra-time mode (correct answers add time)
-cargo run -p heads_up -- -x --bonus-seconds 3      # add 3s per correct answer
-cargo run -p heads_up -- --category "House Stark"  # only House Stark entries
-cargo run -p heads_up -- -w my_words.txt           # use a custom word list
+cargo run -p guess_up                              # default 60-second game
+cargo run -p guess_up -- -g 90                     # 90-second game
+cargo run -p guess_up -- -s                        # skip the 3-2-1 countdown
+cargo run -p guess_up -- -l                        # unlimited time on the last question
+cargo run -p guess_up -- -x                        # extra-time mode (correct answers add time)
+cargo run -p guess_up -- -x --bonus-seconds 3      # add 3s per correct answer
+cargo run -p guess_up -- --category "House Stark"  # only House Stark entries
+cargo run -p guess_up -- -w my_words.txt           # use a custom word list
 ```
 
 ## Networked Mode
@@ -49,7 +49,7 @@ After each game, both players get a post-game menu to play again, swap roles, or
 ### Hosting a Game
 
 ```bash
-cargo run -p heads_up -- host --relay your-server:7878
+cargo run -p guess_up -- host --relay your-server:7878
 ```
 
 This connects to the relay, creates a room, and displays a 5-letter room code (e.g. `STARK`). Share this code with your opponent. Once they join, you'll pick your role and the game starts.
@@ -57,7 +57,7 @@ This connects to the relay, creates a room, and displays a 5-letter room code (e
 All solo-mode flags work with `host` too:
 
 ```bash
-cargo run -p heads_up -- -g 90 -x --bonus-seconds 3 host --relay your-server:7878
+cargo run -p guess_up -- -g 90 -x --bonus-seconds 3 host --relay your-server:7878
 ```
 
 The host controls the game config — the joiner receives it automatically.
@@ -65,7 +65,7 @@ The host controls the game config — the joiner receives it automatically.
 ### Joining a Game
 
 ```bash
-cargo run -p heads_up -- join --relay your-server:7878 --code STARK
+cargo run -p guess_up -- join --relay your-server:7878 --code STARK
 ```
 
 Enter the room code the host gave you (case-insensitive). You'll see your assigned role, then the game starts. The joiner doesn't need to specify game flags — the host's settings are used.
@@ -81,17 +81,17 @@ The relay is a lightweight TCP server that forwards messages between the two pla
 cargo build --release -p relay
 
 # Copy to your server
-scp target/release/relay your-server:/usr/local/bin/heads-up-relay
+scp target/release/relay your-server:/usr/local/bin/guess-up-relay
 ```
 
 **Run it:**
 
 ```bash
 # Simplest form (binds to 0.0.0.0:7878)
-heads-up-relay
+guess-up-relay
 
 # Custom options
-heads-up-relay --bind 0.0.0.0:9000 --max-rooms 50 --room-timeout 1800
+guess-up-relay --bind 0.0.0.0:9000 --max-rooms 50 --room-timeout 1800
 ```
 
 | Flag | Default | Description |
@@ -108,15 +108,15 @@ sudo ufw allow 7878/tcp
 
 **Run as a systemd service (optional):**
 
-Create `/etc/systemd/system/heads-up-relay.service`:
+Create `/etc/systemd/system/guess-up-relay.service`:
 
 ```ini
 [Unit]
-Description=Heads Up Relay Server
+Description=Guess Up Relay Server
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/heads-up-relay --bind 0.0.0.0:7878
+ExecStart=/usr/local/bin/guess-up-relay --bind 0.0.0.0:7878
 Restart=on-failure
 User=nobody
 Group=nogroup
@@ -127,17 +127,17 @@ WantedBy=multi-user.target
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now heads-up-relay
+sudo systemctl enable --now guess-up-relay
 ```
 
 **Check logs:**
 
 ```bash
 # Direct — tracing output goes to stderr
-RUST_LOG=info heads-up-relay
+RUST_LOG=info guess-up-relay
 
 # Systemd
-journalctl -u heads-up-relay -f
+journalctl -u guess-up-relay -f
 ```
 
 **Verify connectivity from a client machine:**
@@ -179,7 +179,7 @@ Lines are trimmed and deduplicated automatically.
 - **Green/red flash** — visual feedback on correct/pass
 - **Live timer and score** — updated every second
 - **End-of-round summary** — score, accuracy %, pace, and missed words
-- **Game history** — results saved to `~/.heads_up_history.json`
+- **Game history** — results saved to `~/.guess_up_history.json`
 - **Category filtering** — play with only the entries you want
 - **Networked play** — two players on different machines via relay server
 - **Role selection** — host picks Viewer or Holder, swap after each game

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Easy
 
 - [ ] Flash screen effect too short/unreliable — increase duration beyond 150ms (`crates/client/src/render.rs:108`)
-- [ ] Rename all instances of "heads_up" / "Heads Up" to "guess_up" / "Guess Up" across codebase
+- [x] Rename all instances of "heads_up" / "Heads Up" to "guess_up" / "Guess Up" across codebase
 - [ ] Low-time warning — visual cue when timer is running low (e.g. last 10s border turns red or timer text changes color)
 - [ ] Custom word list support — allow users to create/import their own themed word lists beyond ASOIAF
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Easy
 
-- [ ] Flash screen effect too short/unreliable — increase duration beyond 150ms (`crates/client/src/render.rs:108`)
+- [x] Flash screen effect too short/unreliable — increase duration beyond 150ms (`crates/client/src/render.rs:108`)
 - [x] Rename all instances of "heads_up" / "Heads Up" to "guess_up" / "Guess Up" across codebase
 - [ ] Low-time warning — visual cue when timer is running low (e.g. last 10s border turns red or timer text changes color)
 - [ ] Custom word list support — allow users to create/import their own themed word lists beyond ASOIAF

--- a/crates/client/src/game.rs
+++ b/crates/client/src/game.rs
@@ -394,7 +394,7 @@ fn save_history(state: &GameState, config: &GameConfig) {
     let Some(home) = dirs::home_dir() else {
         return;
     };
-    let path = home.join(".heads_up_history.json");
+    let path = home.join(".guess_up_history.json");
 
     let mut history: Vec<GameResult> = if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()

--- a/crates/client/src/game.rs
+++ b/crates/client/src/game.rs
@@ -79,6 +79,9 @@ pub async fn run_game(
         };
     };
 
+    // Track whether a flash animation is playing to avoid clobbering it
+    let mut flashing = false;
+
     // Render initial state based on role
     render_for_role(first_word, &state, local_role);
 
@@ -125,6 +128,7 @@ pub async fn run_game(
                 match action {
                     UserAction::Correct => {
                         state.score += 1;
+                        flashing = true;
                         render::flash_correct(flash_tx.clone());
                         if let Some(ref tx) = net_tx {
                             let _ = tx.send(GameMessage::Flash(FlashKind::Correct)).await;
@@ -137,6 +141,7 @@ pub async fn run_game(
                     }
                     UserAction::Pass => {
                         state.missed_words.push(current);
+                        flashing = true;
                         render::flash_incorrect(flash_tx.clone());
                         if let Some(ref tx) = net_tx {
                             let _ = tx.send(GameMessage::Flash(FlashKind::Incorrect)).await;
@@ -159,7 +164,9 @@ pub async fn run_game(
 
                 match state.current_word() {
                     Some(word) => {
-                        render_for_role(word, &state, local_role);
+                        if !flashing {
+                            render_for_role(word, &state, local_role);
+                        }
                         if let Some(ref tx) = net_tx {
                             let _ = tx
                                 .send(GameMessage::WordUpdate {
@@ -176,8 +183,10 @@ pub async fn run_game(
             }
             GameEvent::TimerTick(remaining) => {
                 state.seconds_left = remaining;
-                if let Some(word) = state.current_word() {
-                    render_for_role(word, &state, local_role);
+                if !flashing {
+                    if let Some(word) = state.current_word() {
+                        render_for_role(word, &state, local_role);
+                    }
                 }
                 if let Some(ref tx) = net_tx {
                     let _ = tx
@@ -222,6 +231,7 @@ pub async fn run_game(
                 }
             }
             GameEvent::Redraw => {
+                flashing = false;
                 if let Some(word) = state.current_word() {
                     render_for_role(word, &state, local_role);
                 }
@@ -286,6 +296,7 @@ pub async fn run_remote_game(
     let mut seconds_left: u64 = 0;
     let mut score: usize = 0;
     let mut total: usize = 0;
+    let mut flashing = false;
 
     loop {
         let Some(event) = rx.recv().await else {
@@ -295,23 +306,27 @@ pub async fn run_remote_game(
         match event {
             GameEvent::NetWordUpdate(word) => {
                 current_word = word;
-                match role {
-                    Role::Viewer => {
-                        render::render_question(&current_word, seconds_left, score, term_size);
-                    }
-                    Role::Holder => {
-                        render::render_holder_view(seconds_left, score, term_size);
+                if !flashing {
+                    match role {
+                        Role::Viewer => {
+                            render::render_question(&current_word, seconds_left, score, term_size);
+                        }
+                        Role::Holder => {
+                            render::render_holder_view(seconds_left, score, term_size);
+                        }
                     }
                 }
             }
             GameEvent::NetTimerSync(secs) => {
                 seconds_left = secs;
-                match role {
-                    Role::Viewer => {
-                        render::render_question(&current_word, seconds_left, score, term_size);
-                    }
-                    Role::Holder => {
-                        render::render_holder_view(seconds_left, score, term_size);
+                if !flashing {
+                    match role {
+                        Role::Viewer => {
+                            render::render_question(&current_word, seconds_left, score, term_size);
+                        }
+                        Role::Holder => {
+                            render::render_holder_view(seconds_left, score, term_size);
+                        }
                     }
                 }
             }
@@ -319,10 +334,13 @@ pub async fn run_remote_game(
                 score = s;
                 total = t;
             }
-            GameEvent::NetFlash(kind) => match kind {
-                protocol::FlashKind::Correct => render::flash_correct(flash_tx.clone()),
-                protocol::FlashKind::Incorrect => render::flash_incorrect(flash_tx.clone()),
-            },
+            GameEvent::NetFlash(kind) => {
+                flashing = true;
+                match kind {
+                    protocol::FlashKind::Correct => render::flash_correct(flash_tx.clone()),
+                    protocol::FlashKind::Incorrect => render::flash_incorrect(flash_tx.clone()),
+                }
+            }
             GameEvent::NetTimerExpired => {
                 render::bell();
             }
@@ -355,14 +373,17 @@ pub async fn run_remote_game(
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 break;
             }
-            GameEvent::Redraw => match role {
-                Role::Viewer => {
-                    render::render_question(&current_word, seconds_left, score, term_size);
+            GameEvent::Redraw => {
+                flashing = false;
+                match role {
+                    Role::Viewer => {
+                        render::render_question(&current_word, seconds_left, score, term_size);
+                    }
+                    Role::Holder => {
+                        render::render_holder_view(seconds_left, score, term_size);
+                    }
                 }
-                Role::Holder => {
-                    render::render_holder_view(seconds_left, score, term_size);
-                }
-            },
+            }
             _ => {}
         }
     }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -15,7 +15,7 @@ use types::*;
 #[derive(Parser, Debug)]
 #[command(
     version,
-    about = "ASOIAF Heads Up! — A Song of Ice and Fire themed party game"
+    about = "ASOIAF Guess Up! — A Song of Ice and Fire themed party game"
 )]
 struct Args {
     /// Game length in seconds

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -111,7 +111,7 @@ pub async fn flash_screen(color: Color, tx: EventSender) {
         SetColors(Colors::new(Black, color)),
         Clear(terminal::ClearType::All),
     );
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
     let _ = execute!(
         stdout(),
         SetColors(Colors::new(White, Blue)),

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -111,7 +111,7 @@ pub async fn flash_screen(color: Color, tx: EventSender) {
         SetColors(Colors::new(Black, color)),
         Clear(terminal::ClearType::All),
     );
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
     let _ = execute!(
         stdout(),
         SetColors(Colors::new(White, Blue)),

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -18,7 +18,7 @@ impl TerminalGuard {
         let _ = execute!(
             stdout(),
             EnterAlternateScreen,
-            terminal::SetTitle("ASOIAF Heads Up"),
+            terminal::SetTitle("ASOIAF Guess Up"),
             SetColors(Colors::new(White, Blue)),
             DisableBlinking,
             Hide,

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
 
 #[derive(Parser, Debug)]
-#[command(version, about = "Heads Up relay server")]
+#[command(version, about = "Guess Up relay server")]
 struct Args {
     /// Address to bind to
     #[arg(long, default_value = "0.0.0.0:7878")]


### PR DESCRIPTION
## Summary

- Rename all instances of "heads_up" / "Heads Up" to "guess_up" / "Guess Up" across source code, documentation, and plan files
- Fix flash screen effect not rendering — the game loop was immediately re-rendering the next question after spawning the flash, clobbering it before it was visible. Added a `flashing` flag to both game loops that defers renders until the `Redraw` event fires after the flash completes

## Test plan

- [x] `cargo run -p guess_up` — solo mode works end-to-end
- [x] Flash effect is reliably visible on correct (`y`) and pass (`n`)
- [x] `TimerTick` renders don't clobber the flash mid-animation
- [x] `cargo clippy` and `cargo fmt --check` pass clean
- [x] Networked mode: flash visible on both host and joiner sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)