### PR TITLE
Replace clap CLI with interactive TUI menu system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,19 +10,13 @@ An ASOIAF (A Song of Ice and Fire) themed "Heads Up" party game for the terminal
 
 ```bash
 cargo build --release                          # build all crates
-cargo run -p heads_up                          # solo mode, default 60s game
-cargo run -p heads_up -- -x --bonus-seconds 3  # extra-time mode
-cargo run -p heads_up -- --category "House Stark"  # filter by category
-
-# Networked mode
-cargo run -p heads_up -- host --relay server:7878
-cargo run -p heads_up -- join --relay server:7878 --code ABCDE
+cargo run -p guess_up                          # launches TUI menu
 
 # Relay server
 cargo run -p relay                             # binds to 0.0.0.0:7878
 ```
 
-CLI flags: `-g` (game time), `-s` (skip countdown), `-l` (last unlimited), `-x` (extra time), `--bonus-seconds`, `-w` (word file), `--category`. Flags go before the subcommand (`host`/`join`).
+All game settings (game time, categories, extra-time mode, relay server, etc.) are configured through the interactive TUI menu. Settings persist between sessions in `~/.heads_up_config.json`. No CLI flags needed for the client.
 
 ## Coding Standards
 
@@ -58,14 +52,16 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 
 | Module | Responsibility |
 |--------|---------------|
-| `main.rs` | CLI args (clap), word loading with category parsing, channel setup, task spawning |
+| `main.rs` | Word loading with category parsing, game runners (solo/host/join), entry point |
+| `config.rs` | `AppConfig` struct, defaults, load/save `~/.heads_up_config.json`, `to_game_config()` |
+| `menu.rs` | TUI menu state machine (`menu_loop`), all screens (main, settings, category picker, server connect, join room), game dispatch |
 | `types.rs` | `GameEvent`, `UserAction`, `GameMode`, `GameConfig`, `GameResult`, type aliases |
 | `game.rs` | `GameState`, game loop (`tokio::select!`), Fisher-Yates shuffle, history saving. `run_game` is the host/solo loop, `run_remote_game` is the joiner's display-only loop |
 | `input.rs` | `input_task()` — crossterm `EventStream`, single-keypress in raw mode |
 | `timer.rs` | `timer_task()` — 1s interval ticks, bonus-time channel for extra-time mode |
-| `render.rs` | `TerminalGuard` (RAII cleanup), rendering, flash, countdown, lobby screens, summary output |
+| `render.rs` | `TerminalGuard` (RAII cleanup), `MenuItem` enum, menu rendering, game rendering, flash, countdown, lobby screens, summary output |
 | `net.rs` | `NetConnection` (TCP connect/split/reassemble), `NetHandle` (spawn read/write tasks, recoverable shutdown) |
-| `lobby.rs` | Room creation, role selection, joiner handshake, post-game menu (play again / swap roles / quit) |
+| `lobby.rs` | Room creation, host lobby (wait for peer with settings), role selection (with settings), joiner session loop, post-game menu, connection recovery across games |
 
 The key invariant is that `input.rs` stays separate from `game.rs` to allow swapping input sources.
 
@@ -74,8 +70,12 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 - **TerminalGuard**: RAII pattern with `Drop` — ensures raw mode and alternate screen are cleaned up on panic or early exit.
 - **Flash race condition**: `flash_screen()` clobbers the display; after 150ms it sends `GameEvent::Redraw` so the game loop re-renders the current word.
 - **Summary rendering**: `TerminalGuard` must be dropped *before* `print_output()` — otherwise the summary prints inside the alternate screen buffer and gets wiped.
-- **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting.
+- **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting. Both host and joiner recover connections after each game for multi-round play.
 - **Host-authoritative model**: The host owns all game state (words, timer, score). The joiner runs `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput`, Holder processes `UserInput`.
+- **Joiner post-game**: After a game, the joiner waits for the host's next `RoleAssignment` (signaling a new round) rather than intermediate `PlayAgain`/`SwapRoles` messages. This avoids a race condition where the net read task could consume messages during shutdown.
+- **Menu-driven game dispatch**: `menu_loop` owns the full lifecycle — it runs games internally and loops back to the appropriate screen (server connect, room code) after each game ends, preserving menu state.
+- **Settings persistence**: `AppConfig` is loaded from `~/.heads_up_config.json` on startup and saved after each menu exit or game. `#[serde(default)]` ensures forward compatibility.
+- **Address validation**: Relay server addresses are validated (host:port format, numeric port 1-65535) before connection attempts. Errors display inline in red on the input screen.
 - **Word loading**: Parses `[Category]` headers, trims lines, deduplicates via `HashSet` (case-insensitive).
 - **History**: Saved to `~/.heads_up_history.json` via serde.
 
@@ -90,13 +90,16 @@ The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`
 
 Manual play-testing is the primary test strategy. Key scenarios to verify:
 
-1. `cargo run -p heads_up` — normal mode works end-to-end
-2. `cargo run -p heads_up -- --last-unlimited` — last question gets infinite time
-3. `cargo run -p heads_up -- --extra-time --bonus-seconds 3` — bonus time adds correctly
-4. `cargo run -p heads_up -- --category "House Stark"` — category filtering works
-5. Ctrl+C during game — terminal restores cleanly
-6. `~/.heads_up_history.json` is written after a game
-7. Networked mode: host + join, role selection, play-again flow, peer disconnect handling
+1. `cargo run -p guess_up` — main menu renders, arrow/hjkl navigation works
+2. Settings → change game_time → exit → re-run → value persisted in `~/.heads_up_config.json`
+3. Solo → plays full game → returns to main menu
+4. Category picker → scroll through categories → select one → only those words appear
+5. Host → server connect screen → type address → connect → room created → settings accessible while waiting
+6. Join → server connect → enter room code → wrong code shows error inline → correct code joins
+7. Networked: host + join, role selection, play-again/swap-roles flow, peer disconnect handling
+8. Room stays alive across games — PlayAgain and SwapRoles work without reconnecting
+9. Ctrl+C during game — terminal restores cleanly
+10. `~/.heads_up_history.json` is written after a game
 
 ## Working With Claude
 
@@ -124,7 +127,6 @@ Violating this rule means lost work, broken workflows, and angry maintainers. **
 ## Future Plans
 
 - **Game history CLI viewer**: View `~/.heads_up_history.json` from the command line.
-- **Multi-round / replay**: "Play again?" prompt after a solo round.
 - **Configurable key bindings**: Currently hardcoded to y/n/q.
 
 ## Word List

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,6 @@ name = "guess_up"
 version = "0.2.0"
 dependencies = [
  "chrono",
- "clap",
  "crossterm",
  "dirs",
  "futures",

--- a/README.md
+++ b/README.md
@@ -12,63 +12,34 @@ Requires [Rust](https://www.rust-lang.org/tools/install). If you run into versio
 # Build everything (client + relay server)
 cargo build --release
 
-# Play solo — default 60-second game
-cargo run -p heads_up
-
-# Or play networked (see sections below)
-cargo run -p heads_up -- host --relay your-server:7878
-cargo run -p heads_up -- join --relay your-server:7878 --code ABCDE
+# Launch the game
+cargo run -p guess_up
 ```
+
+An interactive TUI menu lets you configure everything — game time, categories, extra-time mode, relay server address — without any command-line flags. Settings persist between sessions in `~/.heads_up_config.json`.
 
 Press `q` at any time to quit. The terminal always restores cleanly, even on Ctrl+C.
 
 ## Solo Mode
 
-When you run without a subcommand, you get the original single-device experience:
-
-```bash
-cargo run -p heads_up                              # default 60-second game
-cargo run -p heads_up -- -g 90                     # 90-second game
-cargo run -p heads_up -- -s                        # skip the 3-2-1 countdown
-cargo run -p heads_up -- -l                        # unlimited time on the last question
-cargo run -p heads_up -- -x                        # extra-time mode (correct answers add time)
-cargo run -p heads_up -- -x --bonus-seconds 3      # add 3s per correct answer
-cargo run -p heads_up -- --category "House Stark"  # only House Stark entries
-cargo run -p heads_up -- -w my_words.txt           # use a custom word list
-```
+Select **Solo Game** from the main menu. Adjust settings (game time, category, extra-time mode, etc.) via the **Settings** screen before starting.
 
 ## Networked Mode
 
-Two players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and the other **joins** with a room code. After connecting, the host picks roles:
+Two players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and the other **joins** with a room code.
+
+### Hosting a Game
+
+Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code and lets you adjust **Settings** while waiting for an opponent. Once a joiner connects, pick your role:
 
 - **Viewer** — sees the word on screen and gives verbal clues
 - **Holder** — guesses based on clues and presses `y`/`n`
 
-After each game, both players get a post-game menu to play again, swap roles, or quit.
-
-### Hosting a Game
-
-```bash
-cargo run -p heads_up -- host --relay your-server:7878
-```
-
-This connects to the relay, creates a room, and displays a 5-letter room code (e.g. `STARK`). Share this code with your opponent. Once they join, you'll pick your role and the game starts.
-
-All solo-mode flags work with `host` too:
-
-```bash
-cargo run -p heads_up -- -g 90 -x --bonus-seconds 3 host --relay your-server:7878
-```
-
-The host controls the game config — the joiner receives it automatically.
+After each game, the host gets a post-game menu to play again, swap roles, or quit. The room stays alive across games — no need to reconnect.
 
 ### Joining a Game
 
-```bash
-cargo run -p heads_up -- join --relay your-server:7878 --code STARK
-```
-
-Enter the room code the host gave you (case-insensitive). You'll see your assigned role, then the game starts. The joiner doesn't need to specify game flags — the host's settings are used.
+Select **Join Game** from the main menu, enter the relay server address, then type the room code the host gave you. If the code is wrong, the error appears inline so you can fix it and retry. After the game, you stay in the lobby and can join another round when the host starts one.
 
 ### Relay Server Setup
 
@@ -146,17 +117,20 @@ journalctl -u heads-up-relay -f
 nc -zv your-server 7878
 ```
 
-## CLI Flags
+## Menu Navigation
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `-g, --game-time <seconds>` | 60 | Game length in seconds |
-| `-s, --skip-countdown` | off | Skip the 3-2-1 countdown |
-| `-l, --last-unlimited` | off | Give unlimited time on the final question |
-| `-x, --extra-time` | off | Correct answers add bonus time |
-| `--bonus-seconds <n>` | 5 | Seconds added per correct answer (with `-x`) |
-| `-w, --word-file <path>` | `files/ASOIAF_list.txt` | Path to a word list file |
-| `--category <name>` | all | Filter to a specific category |
+All menus use the same controls:
+
+| Key | Action |
+|-----|--------|
+| `↑` / `k` | Move selection up |
+| `↓` / `j` | Move selection down |
+| `Enter` | Select / confirm |
+| `Esc` / `q` | Go back / quit |
+| `←` / `h` | Decrease value (settings) |
+| `→` / `l` | Increase value (settings) |
+
+In text input fields (server address, room code), type normally. `Enter` confirms, `Esc` cancels.
 
 ## Word List Format
 
@@ -175,15 +149,19 @@ Lines are trimmed and deduplicated automatically.
 
 ## Game Features
 
+- **Interactive TUI menu** — configure all settings from the game, no CLI flags needed
+- **Persistent settings** — saved to `~/.heads_up_config.json` between sessions
 - **Single-keypress input** — `y`/`n`/`q` register instantly, no Enter required
 - **Green/red flash** — visual feedback on correct/pass
 - **Live timer and score** — updated every second
 - **End-of-round summary** — score, accuracy %, pace, and missed words
 - **Game history** — results saved to `~/.heads_up_history.json`
-- **Category filtering** — play with only the entries you want
+- **Category filtering** — scrollable picker with all 25 categories
 - **Networked play** — two players on different machines via relay server
 - **Role selection** — host picks Viewer or Holder, swap after each game
-- **Post-game menu** — play again, swap roles, or quit
+- **Post-game menu** — play again, swap roles, or quit (room stays alive)
+- **Address validation** — relay addresses validated before connecting
+- **Recent servers** — last 10 relay addresses remembered
 
 ## Architecture
 
@@ -208,7 +186,9 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 
 | Module | Responsibility |
 |--------|---------------|
-| `main.rs` | CLI args, word loading, channel setup, task spawning |
+| `main.rs` | Word loading, game runners (solo/host/join), entry point |
+| `config.rs` | `AppConfig` — persistent settings, load/save `~/.heads_up_config.json` |
+| `menu.rs` | TUI menu system — main menu, settings, server connect, room code screens |
 | `types.rs` | Event types, game config, result structs |
 | `game.rs` | Game state, main loop (solo + host), remote game loop |
 | `input.rs` | Async single-keypress input via crossterm |

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 protocol = { path = "../protocol" }
-clap = { version = "4.5", features = ["derive"] }
 crossterm = { version = "0.27", features = ["event-stream"] }
 rand = "0.8"
 tokio = { version = "1.39", features = ["macros", "rt-multi-thread", "time", "sync", "net"] }

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -1,0 +1,79 @@
+use crate::types::{GameConfig, GameMode};
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+const CONFIG_FILENAME: &str = ".heads_up_config.json";
+const MAX_RECENT_SERVERS: usize = 10;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AppConfig {
+    pub game_time: u64,
+    pub skip_countdown: bool,
+    pub last_unlimited: bool,
+    pub extra_time: bool,
+    pub bonus_seconds: u64,
+    pub word_file: String,
+    pub category: Option<String>,
+    pub recent_servers: Vec<String>,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            game_time: 60,
+            skip_countdown: false,
+            last_unlimited: false,
+            extra_time: false,
+            bonus_seconds: 5,
+            word_file: "files/ASOIAF_list.txt".to_string(),
+            category: None,
+            recent_servers: Vec::new(),
+        }
+    }
+}
+
+impl AppConfig {
+    pub fn load() -> Self {
+        let Some(home) = dirs::home_dir() else {
+            return Self::default();
+        };
+        let path = home.join(CONFIG_FILENAME);
+        match fs::read_to_string(&path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self) {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let path = home.join(CONFIG_FILENAME);
+        if let Ok(json) = serde_json::to_string_pretty(self) {
+            let _ = fs::write(&path, json);
+        }
+    }
+
+    pub fn to_game_config(&self) -> GameConfig {
+        GameConfig {
+            game_time: self.game_time,
+            skip_countdown: self.skip_countdown,
+            last_unlimited: self.last_unlimited,
+            mode: if self.extra_time {
+                GameMode::ExtraTime {
+                    bonus_seconds: self.bonus_seconds,
+                }
+            } else {
+                GameMode::Normal
+            },
+        }
+    }
+
+    /// Push a server address to the front of recent_servers, deduplicating.
+    pub fn push_recent_server(&mut self, addr: &str) {
+        self.recent_servers.retain(|s| s != addr);
+        self.recent_servers.insert(0, addr.to_string());
+        self.recent_servers.truncate(MAX_RECENT_SERVERS);
+    }
+}

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -504,11 +504,11 @@ async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameActi
                     match key.code {
                         KeyCode::Char('p') | KeyCode::Char('P') => {
                             conn.send_client_msg(&ClientMessage::GameData(GameMessage::PlayAgain)).await?;
-                            return wait_for_peer_post_game(conn).await;
+                            return Ok(PostGameAction::PlayAgain);
                         }
                         KeyCode::Char('s') | KeyCode::Char('S') => {
                             conn.send_client_msg(&ClientMessage::GameData(GameMessage::SwapRoles)).await?;
-                            return wait_for_peer_post_game(conn).await;
+                            return Ok(PostGameAction::SwapRoles);
                         }
                         KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
                             conn.send_client_msg(&ClientMessage::GameData(GameMessage::QuitSession)).await?;
@@ -536,31 +536,6 @@ async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameActi
                     _ => {}
                 }
             }
-        }
-    }
-}
-
-async fn wait_for_peer_post_game(conn: &mut NetConnection) -> io::Result<PostGameAction> {
-    let term_size = render::terminal_size();
-    render::render_message("Waiting for opponent...", term_size);
-
-    loop {
-        match conn.recv_relay_msg().await? {
-            Some(RelayMessage::GameData(GameMessage::PlayAgain)) => {
-                return Ok(PostGameAction::PlayAgain);
-            }
-            Some(RelayMessage::GameData(GameMessage::SwapRoles)) => {
-                return Ok(PostGameAction::SwapRoles);
-            }
-            Some(RelayMessage::GameData(GameMessage::QuitSession))
-            | Some(RelayMessage::PeerDisconnected)
-            | None => {
-                return Ok(PostGameAction::Quit);
-            }
-            Some(RelayMessage::Ping) => {
-                conn.send_client_msg(&ClientMessage::Pong).await?;
-            }
-            _ => {}
         }
     }
 }

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -292,35 +292,77 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
     let mut guard = Some(render::TerminalGuard::new());
     let term_size = render::terminal_size();
     render::render_joined_room(room_code, term_size);
+    let mut waiting_for_next_round = false;
 
     loop {
-        // Wait for role assignment from host
-        let my_role = loop {
-            match conn.recv_relay_msg().await? {
-                Some(RelayMessage::GameData(GameMessage::RoleAssignment { host_role })) => {
-                    let role = match host_role {
-                        Role::Viewer => Role::Holder,
-                        Role::Holder => Role::Viewer,
-                    };
-                    conn.send_client_msg(&ClientMessage::GameData(GameMessage::RoleAccepted))
-                        .await?;
-                    let term_size = render::terminal_size();
-                    render::render_role_assigned(role, term_size);
-                    break role;
+        // Ensure we're in alternate screen
+        if guard.is_none() {
+            guard = Some(render::TerminalGuard::new());
+        }
+
+        // Wait for role assignment from host. Between rounds the joiner
+        // can press Q to quit. We also accept (and ignore) PlayAgain /
+        // SwapRoles messages — only RoleAssignment starts the next round.
+        let my_role = {
+            let msg = if waiting_for_next_round {
+                "Waiting for host..."
+            } else {
+                "Waiting for host to choose roles..."
+            };
+            let term_size = render::terminal_size();
+            render::render_message(msg, term_size);
+
+            let mut reader = EventStream::new();
+            loop {
+                tokio::select! {
+                    event = reader.next() => {
+                        if let Some(Ok(Event::Key(key))) = event {
+                            if key.kind == KeyEventKind::Press
+                                && matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc)
+                            {
+                                let _ = conn
+                                    .send_client_msg(&ClientMessage::GameData(
+                                        GameMessage::QuitSession,
+                                    ))
+                                    .await;
+                                return Ok(());
+                            }
+                        }
+                    }
+                    msg = conn.recv_relay_msg() => {
+                        match msg? {
+                            Some(RelayMessage::GameData(GameMessage::RoleAssignment {
+                                host_role,
+                            })) => {
+                                let role = match host_role {
+                                    Role::Viewer => Role::Holder,
+                                    Role::Holder => Role::Viewer,
+                                };
+                                conn.send_client_msg(&ClientMessage::GameData(
+                                    GameMessage::RoleAccepted,
+                                ))
+                                .await?;
+                                let term_size = render::terminal_size();
+                                render::render_role_assigned(role, term_size);
+                                break role;
+                            }
+                            Some(RelayMessage::Ping) => {
+                                conn.send_client_msg(&ClientMessage::Pong).await?;
+                            }
+                            Some(RelayMessage::PeerDisconnected) | None => {
+                                let term_size = render::terminal_size();
+                                render::render_message("Host disconnected", term_size);
+                                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                                return Ok(());
+                            }
+                            Some(RelayMessage::GameData(GameMessage::QuitSession)) => {
+                                return Ok(());
+                            }
+                            // Ignore PlayAgain/SwapRoles — we only care about RoleAssignment
+                            _ => {}
+                        }
+                    }
                 }
-                Some(RelayMessage::Ping) => {
-                    conn.send_client_msg(&ClientMessage::Pong).await?;
-                }
-                Some(RelayMessage::PeerDisconnected) | None => {
-                    let term_size = render::terminal_size();
-                    render::render_message("Host disconnected", term_size);
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    return Ok(());
-                }
-                Some(RelayMessage::GameData(GameMessage::QuitSession)) => {
-                    return Ok(());
-                }
-                _ => {}
             }
         };
 
@@ -359,15 +401,8 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
         guard.take();
         print_summary(&summary);
 
-        // Re-enter alternate screen and wait for host's post-game decision
-        guard = Some(render::TerminalGuard::new());
-        let post_action = joiner_wait_post_game(&mut conn).await?;
-        match post_action {
-            PostGameAction::PlayAgain | PostGameAction::SwapRoles => {
-                // Host will send a new RoleAssignment — loop back to top
-            }
-            PostGameAction::Quit => return Ok(()),
-        }
+        // Next iteration will re-enter alt screen and wait for RoleAssignment
+        waiting_for_next_round = true;
     }
 }
 
@@ -390,49 +425,6 @@ async fn run_joiner_game(
 
     let recovered = net_handle.shutdown().await;
     (summary, recovered)
-}
-
-/// Joiner waits for the host's post-game choice. The joiner can also
-/// press Q to quit, which notifies the host.
-async fn joiner_wait_post_game(conn: &mut NetConnection) -> io::Result<PostGameAction> {
-    let term_size = render::terminal_size();
-    render::render_message("Waiting for host...", term_size);
-
-    let mut reader = EventStream::new();
-    loop {
-        tokio::select! {
-            event = reader.next() => {
-                if let Some(Ok(Event::Key(key))) = event {
-                    if key.kind != KeyEventKind::Press {
-                        continue;
-                    }
-                    if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc) {
-                        let _ = conn.send_client_msg(&ClientMessage::GameData(GameMessage::QuitSession)).await;
-                        return Ok(PostGameAction::Quit);
-                    }
-                }
-            }
-            msg = conn.recv_relay_msg() => {
-                match msg? {
-                    Some(RelayMessage::GameData(GameMessage::RoleAssignment { .. })) |
-                    Some(RelayMessage::GameData(GameMessage::PlayAgain)) => {
-                        return Ok(PostGameAction::PlayAgain);
-                    }
-                    Some(RelayMessage::GameData(GameMessage::SwapRoles)) => {
-                        return Ok(PostGameAction::SwapRoles);
-                    }
-                    Some(RelayMessage::GameData(GameMessage::QuitSession)) |
-                    Some(RelayMessage::PeerDisconnected) | None => {
-                        return Ok(PostGameAction::Quit);
-                    }
-                    Some(RelayMessage::Ping) => {
-                        conn.send_client_msg(&ClientMessage::Pong).await?;
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
 }
 
 // ─── Role selection (host only) ──────────────────────────────────────

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -287,55 +287,94 @@ pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<NetConnec
 }
 
 /// Run the joiner game session on an already-joined connection.
+/// Loops across games until the host quits or disconnects.
 pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io::Result<()> {
-    let _guard = render::TerminalGuard::new();
+    let mut guard = Some(render::TerminalGuard::new());
     let term_size = render::terminal_size();
     render::render_joined_room(room_code, term_size);
 
-    // Wait for role assignment
-    let my_role = loop {
-        match conn.recv_relay_msg().await? {
-            Some(RelayMessage::GameData(GameMessage::RoleAssignment { host_role })) => {
-                let role = match host_role {
-                    Role::Viewer => Role::Holder,
-                    Role::Holder => Role::Viewer,
-                };
-                conn.send_client_msg(&ClientMessage::GameData(GameMessage::RoleAccepted))
-                    .await?;
-                render::render_role_assigned(role, term_size);
-                break role;
-            }
-            Some(RelayMessage::Ping) => {
-                conn.send_client_msg(&ClientMessage::Pong).await?;
-            }
-            Some(RelayMessage::PeerDisconnected) | None => {
-                render::render_message("Host disconnected", term_size);
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                return Ok(());
-            }
-            _ => {}
-        }
-    };
-
-    // Wait for game start
     loop {
-        match conn.recv_relay_msg().await? {
-            Some(RelayMessage::GameData(GameMessage::GameStart(_cfg))) => break,
-            Some(RelayMessage::Ping) => {
-                conn.send_client_msg(&ClientMessage::Pong).await?;
+        // Wait for role assignment from host
+        let my_role = loop {
+            match conn.recv_relay_msg().await? {
+                Some(RelayMessage::GameData(GameMessage::RoleAssignment { host_role })) => {
+                    let role = match host_role {
+                        Role::Viewer => Role::Holder,
+                        Role::Holder => Role::Viewer,
+                    };
+                    conn.send_client_msg(&ClientMessage::GameData(GameMessage::RoleAccepted))
+                        .await?;
+                    let term_size = render::terminal_size();
+                    render::render_role_assigned(role, term_size);
+                    break role;
+                }
+                Some(RelayMessage::Ping) => {
+                    conn.send_client_msg(&ClientMessage::Pong).await?;
+                }
+                Some(RelayMessage::PeerDisconnected) | None => {
+                    let term_size = render::terminal_size();
+                    render::render_message("Host disconnected", term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    return Ok(());
+                }
+                Some(RelayMessage::GameData(GameMessage::QuitSession)) => {
+                    return Ok(());
+                }
+                _ => {}
             }
-            Some(RelayMessage::PeerDisconnected) | None => {
-                render::render_message("Host disconnected", term_size);
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        };
+
+        // Wait for game start
+        loop {
+            match conn.recv_relay_msg().await? {
+                Some(RelayMessage::GameData(GameMessage::GameStart(_cfg))) => break,
+                Some(RelayMessage::Ping) => {
+                    conn.send_client_msg(&ClientMessage::Pong).await?;
+                }
+                Some(RelayMessage::PeerDisconnected) | None => {
+                    let term_size = render::terminal_size();
+                    render::render_message("Host disconnected", term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        // Run remote game, recovering the connection afterward
+        let (summary, recovered_conn) = run_joiner_game(my_role, conn).await;
+
+        conn = match recovered_conn {
+            Some(c) => c,
+            None => {
+                guard.take();
+                print_summary(&summary);
                 return Ok(());
             }
-            _ => {}
+        };
+
+        // Show summary (temporarily leave alternate screen)
+        guard.take();
+        print_summary(&summary);
+
+        // Re-enter alternate screen and wait for host's post-game decision
+        guard = Some(render::TerminalGuard::new());
+        let post_action = joiner_wait_post_game(&mut conn).await?;
+        match post_action {
+            PostGameAction::PlayAgain | PostGameAction::SwapRoles => {
+                // Host will send a new RoleAssignment — loop back to top
+            }
+            PostGameAction::Quit => return Ok(()),
         }
     }
+}
 
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-    // Run remote game
+async fn run_joiner_game(
+    role: Role,
+    conn: NetConnection,
+) -> (game::GameSummary, Option<NetConnection>) {
     let (event_tx, event_rx) = tokio::sync::mpsc::channel::<GameEvent>(32);
     let flash_tx = event_tx.clone();
     let input_tx = event_tx.clone();
@@ -345,15 +384,55 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
 
     let input_handle = tokio::spawn(input::input_task(input_tx));
 
-    let summary = game::run_remote_game(my_role, event_rx, net_tx, flash_tx).await;
+    let summary = game::run_remote_game(role, event_rx, net_tx, flash_tx).await;
 
     input_handle.abort();
-    let _ = net_handle.shutdown().await;
 
-    drop(_guard);
-    print_summary(&summary);
+    let recovered = net_handle.shutdown().await;
+    (summary, recovered)
+}
 
-    Ok(())
+/// Joiner waits for the host's post-game choice. The joiner can also
+/// press Q to quit, which notifies the host.
+async fn joiner_wait_post_game(conn: &mut NetConnection) -> io::Result<PostGameAction> {
+    let term_size = render::terminal_size();
+    render::render_message("Waiting for host...", term_size);
+
+    let mut reader = EventStream::new();
+    loop {
+        tokio::select! {
+            event = reader.next() => {
+                if let Some(Ok(Event::Key(key))) = event {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    if matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc) {
+                        let _ = conn.send_client_msg(&ClientMessage::GameData(GameMessage::QuitSession)).await;
+                        return Ok(PostGameAction::Quit);
+                    }
+                }
+            }
+            msg = conn.recv_relay_msg() => {
+                match msg? {
+                    Some(RelayMessage::GameData(GameMessage::RoleAssignment { .. })) |
+                    Some(RelayMessage::GameData(GameMessage::PlayAgain)) => {
+                        return Ok(PostGameAction::PlayAgain);
+                    }
+                    Some(RelayMessage::GameData(GameMessage::SwapRoles)) => {
+                        return Ok(PostGameAction::SwapRoles);
+                    }
+                    Some(RelayMessage::GameData(GameMessage::QuitSession)) |
+                    Some(RelayMessage::PeerDisconnected) | None => {
+                        return Ok(PostGameAction::Quit);
+                    }
+                    Some(RelayMessage::Ping) => {
+                        conn.send_client_msg(&ClientMessage::Pong).await?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 }
 
 // ─── Role selection (host only) ──────────────────────────────────────

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -1,8 +1,9 @@
 use crate::config::AppConfig;
 use crate::game;
 use crate::input;
+use crate::menu;
 use crate::net::{self, NetConnection};
-use crate::render;
+use crate::render::{self, MenuItem};
 use crate::timer;
 use crate::types::*;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
@@ -16,7 +17,7 @@ pub async fn run_host_session(
     config: GameConfig,
     words: Vec<String>,
     relay_addr: &str,
-    app_config: &AppConfig,
+    app_config: &mut AppConfig,
 ) -> io::Result<()> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
@@ -59,7 +60,7 @@ pub async fn run_host_session(
     }
 
     // Role selection
-    let mut host_role = select_role().await;
+    let mut host_role = select_role(app_config).await;
 
     loop {
         // Ensure we're in alternate screen
@@ -297,21 +298,46 @@ pub async fn run_joiner_session(
 
 // ─── Role selection (host only) ──────────────────────────────────────
 
-async fn select_role() -> Role {
-    let term_size = render::terminal_size();
-    render::render_role_select(term_size);
-
+async fn select_role(app_config: &mut AppConfig) -> Role {
+    let mut selected: usize = 0;
     let mut reader = EventStream::new();
+    let count = 3; // Viewer, Holder, Settings
+
     loop {
-        if let Some(Ok(Event::Key(key))) = reader.next().await {
-            if key.kind != KeyEventKind::Press {
-                continue;
+        let term_size = render::terminal_size();
+        let items = [
+            MenuItem::Action("Viewer — See words, give clues"),
+            MenuItem::Action("Holder — Guess and press Y/N"),
+            MenuItem::Label(""),
+            MenuItem::Action("Settings"),
+        ];
+        render::render_menu("CHOOSE YOUR ROLE", &items, selected, term_size);
+
+        let Some(Ok(event)) = reader.next().await else {
+            continue;
+        };
+        let Event::Key(key) = event else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                selected = selected.checked_sub(1).unwrap_or(count - 1);
             }
-            match key.code {
-                KeyCode::Char('v') | KeyCode::Char('V') => return Role::Viewer,
-                KeyCode::Char('h') | KeyCode::Char('H') => return Role::Holder,
+            KeyCode::Down | KeyCode::Char('j') => {
+                selected = (selected + 1) % count;
+            }
+            KeyCode::Enter => match selected {
+                0 => return Role::Viewer,
+                1 => return Role::Holder,
+                2 => menu::run_settings_inline(app_config, &mut reader).await,
                 _ => {}
-            }
+            },
+            KeyCode::Char('v') | KeyCode::Char('V') => return Role::Viewer,
+            KeyCode::Char('h') | KeyCode::Char('H') => return Role::Holder,
+            _ => {}
         }
     }
 }

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -13,12 +13,7 @@ use std::io::{self, ErrorKind};
 
 // ─── Host session ────────────────────────────────────────────────────
 
-pub async fn run_host_session(
-    config: GameConfig,
-    words: Vec<String>,
-    relay_addr: &str,
-    app_config: &mut AppConfig,
-) -> io::Result<()> {
+pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> io::Result<()> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
             ErrorKind::ConnectionRefused,
@@ -39,34 +34,35 @@ pub async fn run_host_session(
     };
 
     let mut guard = Some(render::TerminalGuard::new());
-    let term_size = render::terminal_size();
-    render::render_waiting_for_peer(&code, term_size);
 
-    // Wait for peer to join
-    loop {
-        match conn.recv_relay_msg().await? {
-            Some(RelayMessage::PeerJoined) => break,
-            Some(RelayMessage::Ping) => {
-                conn.send_client_msg(&ClientMessage::Pong).await?;
-            }
-            None => {
-                return Err(io::Error::new(
-                    ErrorKind::ConnectionAborted,
-                    "Relay disconnected",
-                ));
-            }
-            _ => {}
-        }
+    // Wait for peer (with settings access)
+    let wait_result = wait_for_peer(&code, &mut conn, app_config).await?;
+    if !wait_result {
+        let _ = conn.send_client_msg(&ClientMessage::Disconnect).await;
+        return Ok(());
     }
 
     // Role selection
     let mut host_role = select_role(app_config).await;
 
     loop {
+        // Rebuild config and words from current settings each round
+        let config = app_config.to_game_config();
+        let words = crate::load_words(&app_config.word_file, app_config.category.as_deref());
+        if words.is_empty() {
+            let term_size = render::terminal_size();
+            render::render_message("No words found for current settings!", term_size);
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let _ = conn.send_client_msg(&ClientMessage::Disconnect).await;
+            return Ok(());
+        }
+
         // Ensure we're in alternate screen
         if guard.is_none() {
             guard = Some(render::TerminalGuard::new());
         }
+
+        let term_size = render::terminal_size();
 
         // Send role assignment to joiner
         conn.send_client_msg(&ClientMessage::GameData(GameMessage::RoleAssignment {
@@ -111,11 +107,8 @@ pub async fn run_host_session(
             render::render_countdown(term_size);
         }
 
-        // --- Run the game (net tasks own the connection during this phase) ---
-        let current_words =
-            crate::load_words(&app_config.word_file, app_config.category.as_deref());
-        let (summary, recovered_conn) =
-            run_host_game(&config, current_words, conn, host_role).await;
+        // --- Run the game ---
+        let (summary, recovered_conn) = run_host_game(&config, words, conn, host_role).await;
 
         conn = match recovered_conn {
             Some(c) => c,
@@ -150,6 +143,76 @@ pub async fn run_host_session(
         }
     }
 }
+
+// ─── Wait for peer (with settings menu) ─────────────────────────────
+
+/// Wait for a peer to join the room. Returns `true` if a peer joined,
+/// `false` if the host chose to disconnect.
+async fn wait_for_peer(
+    room_code: &str,
+    conn: &mut NetConnection,
+    app_config: &mut AppConfig,
+) -> io::Result<bool> {
+    let mut reader = EventStream::new();
+    let mut selected: usize = 0;
+    let count = 2; // Settings, Disconnect
+
+    loop {
+        let term_size = render::terminal_size();
+        let code_line = format!("Room: {}", room_code);
+        let items = [
+            MenuItem::Label("WAITING FOR OPPONENT..."),
+            MenuItem::Label(""),
+            MenuItem::Label(&code_line),
+            MenuItem::Label(""),
+            MenuItem::Action("Settings"),
+            MenuItem::Action("Disconnect"),
+        ];
+        render::render_menu("HOST LOBBY", &items, selected, term_size);
+
+        tokio::select! {
+            event = reader.next() => {
+                let Some(Ok(event)) = event else { continue };
+                let Event::Key(key) = event else { continue };
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        selected = selected.checked_sub(1).unwrap_or(count - 1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        selected = (selected + 1) % count;
+                    }
+                    KeyCode::Enter => match selected {
+                        0 => menu::run_settings_inline(app_config, &mut reader).await,
+                        1 => return Ok(false),
+                        _ => {}
+                    },
+                    KeyCode::Esc | KeyCode::Char('q') => return Ok(false),
+                    _ => {}
+                }
+            }
+            msg = conn.recv_relay_msg() => {
+                match msg? {
+                    Some(RelayMessage::PeerJoined) => return Ok(true),
+                    Some(RelayMessage::Ping) => {
+                        conn.send_client_msg(&ClientMessage::Pong).await?;
+                    }
+                    None => {
+                        return Err(io::Error::new(
+                            ErrorKind::ConnectionAborted,
+                            "Relay disconnected",
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+// ─── Host game ──────────────────────────────────────────────────────
 
 async fn run_host_game(
     config: &GameConfig,

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -263,11 +263,9 @@ async fn run_host_game(
 
 // ─── Joiner session ─────────────────────────────────────────────────
 
-pub async fn run_joiner_session(
-    relay_addr: &str,
-    code: &str,
-    _app_config: &AppConfig,
-) -> io::Result<()> {
+/// Connect to the relay and join a room. Returns the established connection
+/// on success, or an error (e.g. bad room code, connection refused).
+pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<NetConnection> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
             ErrorKind::ConnectionRefused,
@@ -282,18 +280,17 @@ pub async fn run_joiner_session(
     .await?;
 
     match conn.recv_relay_msg().await? {
-        Some(RelayMessage::JoinedRoom) => {}
-        Some(RelayMessage::Error(e)) => {
-            return Err(io::Error::other(format!("Relay error: {}", e)));
-        }
-        _ => {
-            return Err(io::Error::other("Unexpected relay response"));
-        }
+        Some(RelayMessage::JoinedRoom) => Ok(conn),
+        Some(RelayMessage::Error(e)) => Err(io::Error::other(format!("{}", e))),
+        _ => Err(io::Error::other("Unexpected relay response")),
     }
+}
 
+/// Run the joiner game session on an already-joined connection.
+pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io::Result<()> {
     let _guard = render::TerminalGuard::new();
     let term_size = render::terminal_size();
-    render::render_joined_room(&code_upper, term_size);
+    render::render_joined_room(room_code, term_size);
 
     // Wait for role assignment
     let my_role = loop {

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -1,10 +1,10 @@
+use crate::config::AppConfig;
 use crate::game;
 use crate::input;
 use crate::net::{self, NetConnection};
 use crate::render;
 use crate::timer;
 use crate::types::*;
-use crate::Args;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures::StreamExt;
 use protocol::{ClientMessage, GameMessage, NetGameConfig, RelayMessage, Role};
@@ -16,7 +16,7 @@ pub async fn run_host_session(
     config: GameConfig,
     words: Vec<String>,
     relay_addr: &str,
-    args: &Args,
+    app_config: &AppConfig,
 ) -> io::Result<()> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
@@ -111,7 +111,8 @@ pub async fn run_host_session(
         }
 
         // --- Run the game (net tasks own the connection during this phase) ---
-        let current_words = crate::load_words(&args.word_file, args.category.as_deref());
+        let current_words =
+            crate::load_words(&app_config.word_file, app_config.category.as_deref());
         let (summary, recovered_conn) =
             run_host_game(&config, current_words, conn, host_role).await;
 
@@ -198,7 +199,11 @@ async fn run_host_game(
 
 // ─── Joiner session ─────────────────────────────────────────────────
 
-pub async fn run_joiner_session(relay_addr: &str, code: &str, _args: &Args) -> io::Result<()> {
+pub async fn run_joiner_session(
+    relay_addr: &str,
+    code: &str,
+    _app_config: &AppConfig,
+) -> io::Result<()> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
             ErrorKind::ConnectionRefused,

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -1,73 +1,18 @@
+mod config;
 mod game;
 mod input;
 mod lobby;
+mod menu;
 mod net;
 mod render;
 mod timer;
 mod types;
 
-use clap::{Parser, Subcommand};
+use config::AppConfig;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use types::*;
-
-#[derive(Parser, Debug)]
-#[command(
-    version,
-    about = "ASOIAF Heads Up! — A Song of Ice and Fire themed party game"
-)]
-struct Args {
-    /// Game length in seconds
-    #[arg(short, long, default_value_t = 60)]
-    game_time: u64,
-
-    /// Skip the 3-2-1 countdown animation
-    #[arg(short, long)]
-    skip_countdown: bool,
-
-    /// Allow unlimited time for the last question when timer expires
-    #[arg(short, long)]
-    last_unlimited: bool,
-
-    /// Enable extra-time mode: correct answers add bonus seconds
-    #[arg(short = 'x', long)]
-    extra_time: bool,
-
-    /// Seconds added per correct answer in extra-time mode
-    #[arg(long, default_value_t = 5)]
-    bonus_seconds: u64,
-
-    /// Path to word list file
-    #[arg(short, long, default_value = "files/ASOIAF_list.txt")]
-    word_file: String,
-
-    /// Filter to a specific category in the word file (e.g. "House Stark")
-    #[arg(long)]
-    category: Option<String>,
-
-    #[command(subcommand)]
-    command: Option<Command>,
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Create a room and wait for an opponent
-    Host {
-        /// Relay server address (host:port)
-        #[arg(long)]
-        relay: String,
-    },
-    /// Join an existing room
-    Join {
-        /// Relay server address (host:port)
-        #[arg(long)]
-        relay: String,
-        /// Room code to join
-        #[arg(long)]
-        code: String,
-    },
-}
 
 pub fn load_words(path: &str, category: Option<&str>) -> Vec<String> {
     let content = fs::read_to_string(Path::new(path)).expect("Could not read word file");
@@ -103,40 +48,54 @@ pub fn load_words(path: &str, category: Option<&str>) -> Vec<String> {
     words
 }
 
+pub fn load_categories(path: &str) -> Vec<String> {
+    let Ok(content) = fs::read_to_string(Path::new(path)) else {
+        return Vec::new();
+    };
+    let mut categories = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            categories.push(trimmed[1..trimmed.len() - 1].to_string());
+        }
+    }
+    categories
+}
+
 #[tokio::main]
 async fn main() {
-    let mut args = Args::parse();
-    let command = args.command.take();
+    let mut config = AppConfig::load();
 
-    match command {
-        None => run_solo(args).await,
-        Some(Command::Host { relay }) => run_host(args, relay).await,
-        Some(Command::Join { relay, code }) => run_join(args, relay, code).await,
+    loop {
+        let _guard = render::TerminalGuard::new();
+        let action = menu::menu_loop(&mut config).await;
+        drop(_guard);
+
+        config.save();
+
+        match action {
+            menu::MenuAction::Solo => run_solo(&config).await,
+            menu::MenuAction::Host { relay_addr } => run_host(&config, &relay_addr).await,
+            menu::MenuAction::Join {
+                relay_addr,
+                room_code,
+            } => run_join(&config, &relay_addr, &room_code).await,
+            menu::MenuAction::Quit => break,
+        }
     }
 }
 
-async fn run_solo(args: Args) {
-    let words = load_words(&args.word_file, args.category.as_deref());
+async fn run_solo(app_config: &AppConfig) {
+    let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
         eprintln!(
             "No words found in '{}' (category: {:?})",
-            args.word_file, args.category
+            app_config.word_file, app_config.category
         );
-        std::process::exit(1);
+        return;
     }
 
-    let config = GameConfig {
-        game_time: args.game_time,
-        skip_countdown: args.skip_countdown,
-        last_unlimited: args.last_unlimited,
-        mode: if args.extra_time {
-            GameMode::ExtraTime {
-                bonus_seconds: args.bonus_seconds,
-            }
-        } else {
-            GameMode::Normal
-        },
-    };
+    let config = app_config.to_game_config();
 
     // Set up terminal (guard ensures cleanup on drop/panic)
     let _guard = render::TerminalGuard::new();
@@ -165,7 +124,7 @@ async fn run_solo(args: Args) {
 
     // Spawn input and timer tasks
     let input_handle = tokio::spawn(input::input_task(input_tx));
-    let timer_handle = tokio::spawn(timer::timer_task(timer_tx, args.game_time, bonus_rx));
+    let timer_handle = tokio::spawn(timer::timer_task(timer_tx, app_config.game_time, bonus_rx));
 
     // Run game loop (blocks until game ends)
     let summary = game::run_game(config, words, event_rx, bonus_sender, flash_tx, None, None).await;
@@ -186,38 +145,25 @@ async fn run_solo(args: Args) {
     );
 }
 
-async fn run_host(args: Args, relay_addr: String) {
-    let words = load_words(&args.word_file, args.category.as_deref());
+async fn run_host(app_config: &AppConfig, relay_addr: &str) {
+    let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
         eprintln!(
             "No words found in '{}' (category: {:?})",
-            args.word_file, args.category
+            app_config.word_file, app_config.category
         );
-        std::process::exit(1);
+        return;
     }
 
-    let config = GameConfig {
-        game_time: args.game_time,
-        skip_countdown: args.skip_countdown,
-        last_unlimited: args.last_unlimited,
-        mode: if args.extra_time {
-            GameMode::ExtraTime {
-                bonus_seconds: args.bonus_seconds,
-            }
-        } else {
-            GameMode::Normal
-        },
-    };
+    let config = app_config.to_game_config();
 
-    if let Err(e) = lobby::run_host_session(config, words, &relay_addr, &args).await {
+    if let Err(e) = lobby::run_host_session(config, words, relay_addr, app_config).await {
         eprintln!("Error: {}", e);
-        std::process::exit(1);
     }
 }
 
-async fn run_join(args: Args, relay_addr: String, code: String) {
-    if let Err(e) = lobby::run_joiner_session(&relay_addr, &code, &args).await {
+async fn run_join(app_config: &AppConfig, relay_addr: &str, room_code: &str) {
+    if let Err(e) = lobby::run_joiner_session(relay_addr, room_code, app_config).await {
         eprintln!("Error: {}", e);
-        std::process::exit(1);
     }
 }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -9,6 +9,8 @@ mod timer;
 mod types;
 
 use config::AppConfig;
+use crossterm::event::{Event, EventStream, KeyEventKind};
+use futures::StreamExt;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -88,10 +90,11 @@ async fn main() {
 async fn run_solo(app_config: &AppConfig) {
     let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
-        eprintln!(
+        show_error(&format!(
             "No words found in '{}' (category: {:?})",
             app_config.word_file, app_config.category
-        );
+        ))
+        .await;
         return;
     }
 
@@ -148,22 +151,39 @@ async fn run_solo(app_config: &AppConfig) {
 async fn run_host(app_config: &AppConfig, relay_addr: &str) {
     let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
-        eprintln!(
+        show_error(&format!(
             "No words found in '{}' (category: {:?})",
             app_config.word_file, app_config.category
-        );
+        ))
+        .await;
         return;
     }
 
     let config = app_config.to_game_config();
 
     if let Err(e) = lobby::run_host_session(config, words, relay_addr, app_config).await {
-        eprintln!("Error: {}", e);
+        show_error(&format!("{}", e)).await;
     }
 }
 
 async fn run_join(app_config: &AppConfig, relay_addr: &str, room_code: &str) {
     if let Err(e) = lobby::run_joiner_session(relay_addr, room_code, app_config).await {
-        eprintln!("Error: {}", e);
+        show_error(&format!("{}", e)).await;
+    }
+}
+
+async fn show_error(msg: &str) {
+    let _guard = render::TerminalGuard::new();
+    let term_size = render::terminal_size();
+    render::render_error(msg, term_size);
+
+    // Wait for any keypress
+    let mut reader = EventStream::new();
+    while let Some(Ok(event)) = reader.next().await {
+        if let Event::Key(key) = event {
+            if key.kind == KeyEventKind::Press {
+                break;
+            }
+        }
     }
 }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -77,7 +77,7 @@ async fn main() {
 
         match action {
             menu::MenuAction::Solo => run_solo(&config).await,
-            menu::MenuAction::Host { relay_addr } => run_host(&config, &relay_addr).await,
+            menu::MenuAction::Host { relay_addr } => run_host(&mut config, &relay_addr).await,
             menu::MenuAction::Join {
                 relay_addr,
                 room_code,
@@ -148,7 +148,7 @@ async fn run_solo(app_config: &AppConfig) {
     );
 }
 
-async fn run_host(app_config: &AppConfig, relay_addr: &str) {
+async fn run_host(app_config: &mut AppConfig, relay_addr: &str) {
     let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
         show_error(&format!(

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -11,6 +11,7 @@ mod types;
 use config::AppConfig;
 use crossterm::event::{Event, EventStream, KeyEventKind};
 use futures::StreamExt;
+use net::NetConnection;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -67,27 +68,11 @@ pub fn load_categories(path: &str) -> Vec<String> {
 #[tokio::main]
 async fn main() {
     let mut config = AppConfig::load();
-
-    loop {
-        let _guard = render::TerminalGuard::new();
-        let action = menu::menu_loop(&mut config).await;
-        drop(_guard);
-
-        config.save();
-
-        match action {
-            menu::MenuAction::Solo => run_solo(&config).await,
-            menu::MenuAction::Host { relay_addr } => run_host(&mut config, &relay_addr).await,
-            menu::MenuAction::Join {
-                relay_addr,
-                room_code,
-            } => run_join(&config, &relay_addr, &room_code).await,
-            menu::MenuAction::Quit => break,
-        }
-    }
+    menu::menu_loop(&mut config).await;
+    config.save();
 }
 
-async fn run_solo(app_config: &AppConfig) {
+pub async fn run_solo(app_config: &AppConfig) {
     let words = load_words(&app_config.word_file, app_config.category.as_deref());
     if words.is_empty() {
         show_error(&format!(
@@ -148,19 +133,19 @@ async fn run_solo(app_config: &AppConfig) {
     );
 }
 
-async fn run_host(app_config: &mut AppConfig, relay_addr: &str) {
+pub async fn run_host(app_config: &mut AppConfig, relay_addr: &str) {
     if let Err(e) = lobby::run_host_session(relay_addr, app_config).await {
         show_error(&format!("{}", e)).await;
     }
 }
 
-async fn run_join(app_config: &AppConfig, relay_addr: &str, room_code: &str) {
-    if let Err(e) = lobby::run_joiner_session(relay_addr, room_code, app_config).await {
+pub async fn run_join(conn: NetConnection, room_code: &str) {
+    if let Err(e) = lobby::run_joiner_session(conn, room_code).await {
         show_error(&format!("{}", e)).await;
     }
 }
 
-async fn show_error(msg: &str) {
+pub async fn show_error(msg: &str) {
     let _guard = render::TerminalGuard::new();
     let term_size = render::terminal_size();
     render::render_error(msg, term_size);

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -149,19 +149,7 @@ async fn run_solo(app_config: &AppConfig) {
 }
 
 async fn run_host(app_config: &mut AppConfig, relay_addr: &str) {
-    let words = load_words(&app_config.word_file, app_config.category.as_deref());
-    if words.is_empty() {
-        show_error(&format!(
-            "No words found in '{}' (category: {:?})",
-            app_config.word_file, app_config.category
-        ))
-        .await;
-        return;
-    }
-
-    let config = app_config.to_game_config();
-
-    if let Err(e) = lobby::run_host_session(config, words, relay_addr, app_config).await {
+    if let Err(e) = lobby::run_host_session(relay_addr, app_config).await {
         show_error(&format!("{}", e)).await;
     }
 }

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -56,7 +56,7 @@ pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
                     KeyCode::Enter => match selected {
                         0 => return MenuAction::Solo,
                         1 => {
-                            let result = run_server_connect(config, true, &mut reader).await;
+                            let result = run_server_connect(&mut *config, true, &mut reader).await;
                             match result {
                                 ServerConnectResult::Selected(addr) => {
                                     config.push_recent_server(&addr);
@@ -69,7 +69,7 @@ pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
                             continue;
                         }
                         2 => {
-                            let result = run_server_connect(config, false, &mut reader).await;
+                            let result = run_server_connect(&mut *config, false, &mut reader).await;
                             match result {
                                 ServerConnectResult::Selected(addr) => {
                                     config.push_recent_server(&addr);
@@ -350,6 +350,30 @@ async fn run_category_picker(
     }
 }
 
+// ─── Address validation ─────────────────────────────────────────────
+
+fn validate_address(addr: &str) -> Result<(), &'static str> {
+    if addr.is_empty() {
+        return Err("Address cannot be empty");
+    }
+    let Some(colon_pos) = addr.rfind(':') else {
+        return Err("Missing port — use host:port (e.g. 192.168.1.5:7878)");
+    };
+    let host = &addr[..colon_pos];
+    let port_str = &addr[colon_pos + 1..];
+    if host.is_empty() {
+        return Err("Host cannot be empty");
+    }
+    if port_str.is_empty() {
+        return Err("Port cannot be empty — use host:port (e.g. server:7878)");
+    }
+    match port_str.parse::<u16>() {
+        Ok(0) => Err("Port must be between 1 and 65535"),
+        Ok(_) => Ok(()),
+        Err(_) => Err("Port must be a number (e.g. 7878)"),
+    }
+}
+
 // ─── Server connect ─────────────────────────────────────────────────
 
 enum ServerConnectResult {
@@ -358,18 +382,23 @@ enum ServerConnectResult {
 }
 
 async fn run_server_connect(
-    config: &AppConfig,
+    config: &mut AppConfig,
     hosting: bool,
     reader: &mut EventStream,
 ) -> ServerConnectResult {
     let mut input_buf = String::new();
     let mut editing = true;
-    // selectable items: text input + each recent server + Back
-    let recent_count = config.recent_servers.len();
-    let total_selectable = 1 + recent_count + 1; // input + recents + Back
+    let mut error_msg: Option<&'static str> = None;
     let mut selected: usize = 0; // 0 = text input
 
     loop {
+        // Recalculate selectable count each iteration (recent servers don't change
+        // during this screen, but Settings is only present when hosting)
+        let recent_count = config.recent_servers.len();
+        // selectable: text input + recent servers + [Settings if hosting] + Back
+        let settings_offset = if hosting { 1 } else { 0 };
+        let total_selectable = 1 + recent_count + settings_offset + 1;
+
         let term_size = render::terminal_size();
         let title = if hosting {
             "HOST — RELAY SERVER"
@@ -384,6 +413,10 @@ async fn run_server_connect(
             editing: editing && selected == 0,
         });
 
+        if let Some(err) = error_msg {
+            items.push(MenuItem::Error(err));
+        }
+
         if !config.recent_servers.is_empty() {
             items.push(MenuItem::Label(""));
             items.push(MenuItem::Label("Recent servers:"));
@@ -393,6 +426,9 @@ async fn run_server_connect(
         }
 
         items.push(MenuItem::Label(""));
+        if hosting {
+            items.push(MenuItem::Action("Settings"));
+        }
         items.push(MenuItem::Action("Back"));
 
         render::render_menu(title, &items, selected, term_size);
@@ -407,22 +443,28 @@ async fn run_server_connect(
                 match key.code {
                     KeyCode::Enter => {
                         let addr = input_buf.trim().to_string();
-                        if !addr.is_empty() {
-                            return ServerConnectResult::Selected(addr);
+                        match validate_address(&addr) {
+                            Ok(()) => return ServerConnectResult::Selected(addr),
+                            Err(e) => {
+                                error_msg = Some(e);
+                            }
                         }
-                        editing = false;
                     }
                     KeyCode::Esc => {
                         editing = false;
+                        error_msg = None;
                     }
                     KeyCode::Backspace => {
                         input_buf.pop();
+                        error_msg = None;
                     }
                     KeyCode::Char(c) => {
                         input_buf.push(c);
+                        error_msg = None;
                     }
                     KeyCode::Down | KeyCode::Tab => {
                         editing = false;
+                        error_msg = None;
                         selected = (selected + 1) % total_selectable;
                     }
                     _ => {}
@@ -443,8 +485,11 @@ async fn run_server_connect(
                         // Activate text input editing
                         editing = true;
                     } else if selected == total_selectable - 1 {
-                        // Back
+                        // Back (always last)
                         return ServerConnectResult::Back;
+                    } else if hosting && selected == total_selectable - 2 {
+                        // Settings (second to last when hosting)
+                        run_settings_inline(config, reader).await;
                     } else {
                         // Recent server
                         let server_idx = selected - 1;
@@ -459,6 +504,28 @@ async fn run_server_connect(
                     return ServerConnectResult::Back;
                 }
                 _ => {}
+            }
+        }
+    }
+}
+
+/// Run the full settings screen inline (used from server connect when hosting).
+async fn run_settings_inline(config: &mut AppConfig, reader: &mut EventStream) {
+    let mut selected: usize = 0;
+    loop {
+        let term_size = render::terminal_size();
+        render_settings_menu(config, selected, term_size);
+
+        let result = run_settings_screen(config, &mut selected, reader).await;
+        match result {
+            SettingsResult::Continue => continue,
+            SettingsResult::Back => return,
+            SettingsResult::OpenCategoryPicker => {
+                let categories = crate::load_categories(&config.word_file);
+                let pick = run_category_picker(&categories, config, reader).await;
+                if let Some(cat) = pick {
+                    config.category = cat;
+                }
             }
         }
     }

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -509,8 +509,8 @@ async fn run_server_connect(
     }
 }
 
-/// Run the full settings screen inline (used from server connect when hosting).
-async fn run_settings_inline(config: &mut AppConfig, reader: &mut EventStream) {
+/// Run the full settings screen inline (reusable from any screen).
+pub async fn run_settings_inline(config: &mut AppConfig, reader: &mut EventStream) {
     let mut selected: usize = 0;
     loop {
         let term_size = render::terminal_size();

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -1,0 +1,594 @@
+use crate::config::AppConfig;
+use crate::render::{self, MenuItem};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
+use futures::StreamExt;
+
+pub enum MenuAction {
+    Solo,
+    Host {
+        relay_addr: String,
+    },
+    Join {
+        relay_addr: String,
+        room_code: String,
+    },
+    Quit,
+}
+
+enum Screen {
+    Main,
+    Settings,
+}
+
+pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
+    let mut screen = Screen::Main;
+    let mut selected: usize = 0;
+
+    let mut reader = EventStream::new();
+
+    loop {
+        let term_size = render::terminal_size();
+
+        match &screen {
+            Screen::Main => render_main_menu(selected, term_size),
+            Screen::Settings => render_settings_menu(config, selected, term_size),
+        }
+
+        match &screen {
+            Screen::Main => {
+                let count = 5; // Solo, Host, Join, Settings, Quit
+                let Some(Ok(event)) = reader.next().await else {
+                    continue;
+                };
+                let Event::Key(key) = event else {
+                    continue; // Resize or other events → re-render
+                };
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        selected = selected.checked_sub(1).unwrap_or(count - 1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        selected = (selected + 1) % count;
+                    }
+                    KeyCode::Enter => match selected {
+                        0 => return MenuAction::Solo,
+                        1 => {
+                            let result = run_server_connect(config, true, &mut reader).await;
+                            match result {
+                                ServerConnectResult::Selected(addr) => {
+                                    config.push_recent_server(&addr);
+                                    return MenuAction::Host { relay_addr: addr };
+                                }
+                                ServerConnectResult::Back => {
+                                    selected = 1;
+                                }
+                            }
+                            continue;
+                        }
+                        2 => {
+                            let result = run_server_connect(config, false, &mut reader).await;
+                            match result {
+                                ServerConnectResult::Selected(addr) => {
+                                    config.push_recent_server(&addr);
+                                    let join_result = run_join_room(&addr, &mut reader).await;
+                                    match join_result {
+                                        JoinRoomResult::Joined(code) => {
+                                            return MenuAction::Join {
+                                                relay_addr: addr,
+                                                room_code: code,
+                                            };
+                                        }
+                                        JoinRoomResult::Back => {
+                                            selected = 2;
+                                        }
+                                    }
+                                    continue;
+                                }
+                                ServerConnectResult::Back => {
+                                    selected = 2;
+                                }
+                            }
+                            continue;
+                        }
+                        3 => {
+                            screen = Screen::Settings;
+                            selected = 0;
+                            continue;
+                        }
+                        4 => return MenuAction::Quit,
+                        _ => {}
+                    },
+                    KeyCode::Char('q') | KeyCode::Esc => return MenuAction::Quit,
+                    _ => {}
+                }
+            }
+            Screen::Settings => {
+                let result = run_settings_screen(config, &mut selected, &mut reader).await;
+                match result {
+                    SettingsResult::Continue => continue,
+                    SettingsResult::Back => {
+                        screen = Screen::Main;
+                        selected = 3; // return cursor to Settings
+                        continue;
+                    }
+                    SettingsResult::OpenCategoryPicker => {
+                        let categories = crate::load_categories(&config.word_file);
+                        let pick = run_category_picker(&categories, config, &mut reader).await;
+                        if let Some(cat) = pick {
+                            config.category = cat;
+                        }
+                        screen = Screen::Settings;
+                        // Keep selected on the same item
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ─── Main menu ──────────────────────────────────────────────────────
+
+fn render_main_menu(selected: usize, term_size: (u16, u16)) {
+    let items = [
+        MenuItem::Action("Solo Game"),
+        MenuItem::Action("Host Game"),
+        MenuItem::Action("Join Game"),
+        MenuItem::Action("Settings"),
+        MenuItem::Action("Quit"),
+    ];
+    render::render_menu("ASOIAF HEADS UP!", &items, selected, term_size);
+}
+
+// ─── Settings ───────────────────────────────────────────────────────
+
+enum SettingsResult {
+    Continue,
+    Back,
+    OpenCategoryPicker,
+}
+
+// Settings items indexed as selectable items:
+// 0: Game Time
+// 1: Skip Countdown
+// 2: Last Unlimited
+// 3: Extra Time
+// 4: Bonus Seconds
+// 5: Word File
+// 6: Category
+// 7: Back
+const SETTINGS_COUNT: usize = 8;
+
+fn render_settings_menu(config: &AppConfig, selected: usize, term_size: (u16, u16)) {
+    let game_time_val = format!("< {} >", config.game_time);
+    let skip_val = if config.skip_countdown {
+        "[x]".to_string()
+    } else {
+        "[ ]".to_string()
+    };
+    let last_val = if config.last_unlimited {
+        "[x]".to_string()
+    } else {
+        "[ ]".to_string()
+    };
+    let extra_val = if config.extra_time {
+        "[x]".to_string()
+    } else {
+        "[ ]".to_string()
+    };
+    let bonus_val = format!("< {} >", config.bonus_seconds);
+    let word_file_val = config.word_file.clone();
+    let cat_val = config.category.as_deref().unwrap_or("All").to_string();
+
+    let items = [
+        MenuItem::Setting {
+            label: "Game Time:",
+            value: &game_time_val,
+        },
+        MenuItem::Setting {
+            label: "Skip Countdown:",
+            value: &skip_val,
+        },
+        MenuItem::Setting {
+            label: "Last Unlimited:",
+            value: &last_val,
+        },
+        MenuItem::Setting {
+            label: "Extra Time:",
+            value: &extra_val,
+        },
+        MenuItem::Setting {
+            label: "Bonus Seconds:",
+            value: &bonus_val,
+        },
+        MenuItem::Setting {
+            label: "Word File:",
+            value: &word_file_val,
+        },
+        MenuItem::Setting {
+            label: "Category:",
+            value: &cat_val,
+        },
+        MenuItem::Action("Back"),
+    ];
+    render::render_menu("SETTINGS", &items, selected, term_size);
+}
+
+async fn run_settings_screen(
+    config: &mut AppConfig,
+    selected: &mut usize,
+    reader: &mut EventStream,
+) -> SettingsResult {
+    if let Some(Ok(Event::Key(key))) = reader.next().await {
+        if key.kind != KeyEventKind::Press {
+            return SettingsResult::Continue;
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                *selected = selected.checked_sub(1).unwrap_or(SETTINGS_COUNT - 1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                *selected = (*selected + 1) % SETTINGS_COUNT;
+            }
+            KeyCode::Left | KeyCode::Char('h') => match *selected {
+                0 => config.game_time = config.game_time.saturating_sub(5).max(5),
+                4 => config.bonus_seconds = config.bonus_seconds.saturating_sub(1).max(1),
+                1 => config.skip_countdown = !config.skip_countdown,
+                2 => config.last_unlimited = !config.last_unlimited,
+                3 => config.extra_time = !config.extra_time,
+                _ => {}
+            },
+            KeyCode::Right | KeyCode::Char('l') => match *selected {
+                0 => config.game_time = (config.game_time + 5).min(300),
+                4 => config.bonus_seconds = (config.bonus_seconds + 1).min(30),
+                1 => config.skip_countdown = !config.skip_countdown,
+                2 => config.last_unlimited = !config.last_unlimited,
+                3 => config.extra_time = !config.extra_time,
+                _ => {}
+            },
+            KeyCode::Enter => match *selected {
+                0 => {
+                    // Text input for exact game time
+                    if let Some(val) =
+                        run_text_input_for_number("Game Time (seconds):", config.game_time, reader)
+                            .await
+                    {
+                        config.game_time = val.clamp(5, 300);
+                    }
+                }
+                1 => config.skip_countdown = !config.skip_countdown,
+                2 => config.last_unlimited = !config.last_unlimited,
+                3 => config.extra_time = !config.extra_time,
+                4 => {
+                    if let Some(val) =
+                        run_text_input_for_number("Bonus Seconds:", config.bonus_seconds, reader)
+                            .await
+                    {
+                        config.bonus_seconds = val.clamp(1, 30);
+                    }
+                }
+                5 => {
+                    // Text input for word file path
+                    if let Some(val) = run_text_input("Word File:", &config.word_file, reader).await
+                    {
+                        if !val.is_empty() {
+                            config.word_file = val;
+                        }
+                    }
+                }
+                6 => return SettingsResult::OpenCategoryPicker,
+                7 => return SettingsResult::Back,
+                _ => {}
+            },
+            KeyCode::Esc | KeyCode::Char('q') => return SettingsResult::Back,
+            _ => {}
+        }
+    }
+    SettingsResult::Continue
+}
+
+// ─── Category picker ────────────────────────────────────────────────
+
+async fn run_category_picker(
+    categories: &[String],
+    config: &AppConfig,
+    reader: &mut EventStream,
+) -> Option<Option<String>> {
+    // Build list: "All" + each category
+    let mut items: Vec<String> = vec!["All".to_string()];
+    items.extend(categories.iter().cloned());
+
+    // Find initial selection based on current config
+    let mut selected: usize = match &config.category {
+        None => 0,
+        Some(cat) => items
+            .iter()
+            .position(|c| c.eq_ignore_ascii_case(cat))
+            .unwrap_or(0),
+    };
+    let mut scroll_offset: usize = 0;
+    let visible = 15usize.min(items.len());
+
+    loop {
+        // Adjust scroll to keep selection visible
+        if selected < scroll_offset {
+            scroll_offset = selected;
+        } else if selected >= scroll_offset + visible {
+            scroll_offset = selected - visible + 1;
+        }
+
+        let term_size = render::terminal_size();
+        render::render_category_picker(&items, selected, scroll_offset, term_size);
+
+        if let Some(Ok(Event::Key(key))) = reader.next().await {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.checked_sub(1).unwrap_or(items.len() - 1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1) % items.len();
+                }
+                KeyCode::Enter => {
+                    if selected == 0 {
+                        return Some(None); // "All"
+                    } else {
+                        return Some(Some(items[selected].clone()));
+                    }
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return None; // Cancel, keep current
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// ─── Server connect ─────────────────────────────────────────────────
+
+enum ServerConnectResult {
+    Selected(String),
+    Back,
+}
+
+async fn run_server_connect(
+    config: &AppConfig,
+    hosting: bool,
+    reader: &mut EventStream,
+) -> ServerConnectResult {
+    let mut input_buf = String::new();
+    let mut editing = true;
+    // selectable items: text input + each recent server + Back
+    let recent_count = config.recent_servers.len();
+    let total_selectable = 1 + recent_count + 1; // input + recents + Back
+    let mut selected: usize = 0; // 0 = text input
+
+    loop {
+        let term_size = render::terminal_size();
+        let title = if hosting {
+            "HOST — RELAY SERVER"
+        } else {
+            "JOIN — RELAY SERVER"
+        };
+
+        let mut items: Vec<MenuItem> = Vec::new();
+        items.push(MenuItem::TextInput {
+            label: "Address:",
+            value: &input_buf,
+            editing: editing && selected == 0,
+        });
+
+        if !config.recent_servers.is_empty() {
+            items.push(MenuItem::Label(""));
+            items.push(MenuItem::Label("Recent servers:"));
+            for server in &config.recent_servers {
+                items.push(MenuItem::Action(server));
+            }
+        }
+
+        items.push(MenuItem::Label(""));
+        items.push(MenuItem::Action("Back"));
+
+        render::render_menu(title, &items, selected, term_size);
+
+        if let Some(Ok(Event::Key(key))) = reader.next().await {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            // If we're editing text input
+            if editing && selected == 0 {
+                match key.code {
+                    KeyCode::Enter => {
+                        let addr = input_buf.trim().to_string();
+                        if !addr.is_empty() {
+                            return ServerConnectResult::Selected(addr);
+                        }
+                        editing = false;
+                    }
+                    KeyCode::Esc => {
+                        editing = false;
+                    }
+                    KeyCode::Backspace => {
+                        input_buf.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        input_buf.push(c);
+                    }
+                    KeyCode::Down | KeyCode::Tab => {
+                        editing = false;
+                        selected = (selected + 1) % total_selectable;
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            // Normal navigation
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.checked_sub(1).unwrap_or(total_selectable - 1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1) % total_selectable;
+                }
+                KeyCode::Enter => {
+                    if selected == 0 {
+                        // Activate text input editing
+                        editing = true;
+                    } else if selected == total_selectable - 1 {
+                        // Back
+                        return ServerConnectResult::Back;
+                    } else {
+                        // Recent server
+                        let server_idx = selected - 1;
+                        if server_idx < config.recent_servers.len() {
+                            return ServerConnectResult::Selected(
+                                config.recent_servers[server_idx].clone(),
+                            );
+                        }
+                    }
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return ServerConnectResult::Back;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// ─── Join room ──────────────────────────────────────────────────────
+
+enum JoinRoomResult {
+    Joined(String),
+    Back,
+}
+
+async fn run_join_room(relay_addr: &str, reader: &mut EventStream) -> JoinRoomResult {
+    let mut input_buf = String::new();
+    let mut editing = true;
+    let mut selected: usize = 0; // 0 = text input, 1 = Back
+
+    loop {
+        let term_size = render::terminal_size();
+        let title_text = format!("JOIN — {}", relay_addr);
+
+        let items = [
+            MenuItem::TextInput {
+                label: "Room Code:",
+                value: &input_buf,
+                editing: editing && selected == 0,
+            },
+            MenuItem::Label(""),
+            MenuItem::Action("Back"),
+        ];
+
+        render::render_menu(&title_text, &items, selected, term_size);
+
+        if let Some(Ok(Event::Key(key))) = reader.next().await {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            if editing && selected == 0 {
+                match key.code {
+                    KeyCode::Enter => {
+                        let code = input_buf.trim().to_uppercase();
+                        if !code.is_empty() {
+                            return JoinRoomResult::Joined(code);
+                        }
+                        editing = false;
+                    }
+                    KeyCode::Esc => {
+                        editing = false;
+                    }
+                    KeyCode::Backspace => {
+                        input_buf.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        input_buf.push(c);
+                    }
+                    KeyCode::Down | KeyCode::Tab => {
+                        editing = false;
+                        selected = 1;
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = 0;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = 1;
+                }
+                KeyCode::Enter => {
+                    if selected == 0 {
+                        editing = true;
+                    } else {
+                        return JoinRoomResult::Back;
+                    }
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return JoinRoomResult::Back;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// ─── Text input helpers ─────────────────────────────────────────────
+
+async fn run_text_input(prompt: &str, initial: &str, reader: &mut EventStream) -> Option<String> {
+    let mut buf = initial.to_string();
+
+    loop {
+        let term_size = render::terminal_size();
+        let items = [
+            MenuItem::TextInput {
+                label: prompt,
+                value: &buf,
+                editing: true,
+            },
+            MenuItem::Label(""),
+            MenuItem::Label("Enter to confirm, Esc to cancel"),
+        ];
+        render::render_menu("INPUT", &items, 0, term_size);
+
+        if let Some(Ok(Event::Key(key))) = reader.next().await {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match key.code {
+                KeyCode::Enter => return Some(buf),
+                KeyCode::Esc => return None,
+                KeyCode::Backspace => {
+                    buf.pop();
+                }
+                KeyCode::Char(c) => {
+                    buf.push(c);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+async fn run_text_input_for_number(
+    prompt: &str,
+    initial: u64,
+    reader: &mut EventStream,
+) -> Option<u64> {
+    let result = run_text_input(prompt, &initial.to_string(), reader).await?;
+    result.parse::<u64>().ok()
+}

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -11,10 +11,15 @@ enum Screen {
 pub async fn menu_loop(config: &mut AppConfig) {
     let mut screen = Screen::Main;
     let mut selected: usize = 0;
-
+    let mut guard = Some(render::TerminalGuard::new());
     let mut reader = EventStream::new();
 
     loop {
+        if guard.is_none() {
+            guard = Some(render::TerminalGuard::new());
+            reader = EventStream::new();
+        }
+
         let term_size = render::terminal_size();
 
         match &screen {
@@ -43,6 +48,7 @@ pub async fn menu_loop(config: &mut AppConfig) {
                     }
                     KeyCode::Enter => match selected {
                         0 => {
+                            guard.take();
                             drop(reader);
                             crate::run_solo(config).await;
                             config.save();
@@ -50,13 +56,13 @@ pub async fn menu_loop(config: &mut AppConfig) {
                             continue;
                         }
                         1 => {
-                            run_host_flow(config, &mut reader).await;
+                            run_host_flow(config, &mut guard, &mut reader).await;
                             config.save();
                             selected = 1;
                             continue;
                         }
                         2 => {
-                            run_join_flow(config, &mut reader).await;
+                            run_join_flow(config, &mut guard, &mut reader).await;
                             config.save();
                             selected = 2;
                             continue;
@@ -100,16 +106,22 @@ pub async fn menu_loop(config: &mut AppConfig) {
 
 /// Run the host flow: server connect → game session. Loops back to
 /// server connect after the session ends (disconnect, error, etc).
-async fn run_host_flow(config: &mut AppConfig, reader: &mut EventStream) {
+async fn run_host_flow(
+    config: &mut AppConfig,
+    guard: &mut Option<render::TerminalGuard>,
+    reader: &mut EventStream,
+) {
     loop {
         let result = run_server_connect(config, true, reader).await;
         match result {
             ServerConnectResult::Selected(addr) => {
                 config.push_recent_server(&addr);
+                // Drop guard before game (it manages its own terminal)
+                guard.take();
                 crate::run_host(config, &addr).await;
-                // Recreate reader after game (old one is stale)
+                // Restore guard and reader for the next iteration
+                *guard = Some(render::TerminalGuard::new());
                 *reader = EventStream::new();
-                // Loop back to server connect
             }
             ServerConnectResult::Back => return,
         }
@@ -119,7 +131,11 @@ async fn run_host_flow(config: &mut AppConfig, reader: &mut EventStream) {
 /// Run the join flow: server connect → room code → game session. Loops
 /// back to room code after the session ends. Loops back to server
 /// connect if the user presses Back from the room code screen.
-async fn run_join_flow(config: &mut AppConfig, reader: &mut EventStream) {
+async fn run_join_flow(
+    config: &mut AppConfig,
+    guard: &mut Option<render::TerminalGuard>,
+    reader: &mut EventStream,
+) {
     loop {
         let result = run_server_connect(config, false, reader).await;
         match result {
@@ -130,10 +146,12 @@ async fn run_join_flow(config: &mut AppConfig, reader: &mut EventStream) {
                     let join_result = run_join_room(&addr, reader).await;
                     match join_result {
                         JoinRoomResult::Joined { conn, room_code } => {
+                            // Drop guard before game
+                            guard.take();
                             crate::run_join(conn, &room_code).await;
-                            // Recreate reader after game
+                            // Restore guard and reader
+                            *guard = Some(render::TerminalGuard::new());
                             *reader = EventStream::new();
-                            // Loop back to room code screen
                         }
                         JoinRoomResult::Back => break, // back to server connect
                     }

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -3,24 +3,12 @@ use crate::render::{self, MenuItem};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures::StreamExt;
 
-pub enum MenuAction {
-    Solo,
-    Host {
-        relay_addr: String,
-    },
-    Join {
-        relay_addr: String,
-        room_code: String,
-    },
-    Quit,
-}
-
 enum Screen {
     Main,
     Settings,
 }
 
-pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
+pub async fn menu_loop(config: &mut AppConfig) {
     let mut screen = Screen::Main;
     let mut selected: usize = 0;
 
@@ -54,43 +42,23 @@ pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
                         selected = (selected + 1) % count;
                     }
                     KeyCode::Enter => match selected {
-                        0 => return MenuAction::Solo,
+                        0 => {
+                            drop(reader);
+                            crate::run_solo(config).await;
+                            config.save();
+                            reader = EventStream::new();
+                            continue;
+                        }
                         1 => {
-                            let result = run_server_connect(&mut *config, true, &mut reader).await;
-                            match result {
-                                ServerConnectResult::Selected(addr) => {
-                                    config.push_recent_server(&addr);
-                                    return MenuAction::Host { relay_addr: addr };
-                                }
-                                ServerConnectResult::Back => {
-                                    selected = 1;
-                                }
-                            }
+                            run_host_flow(config, &mut reader).await;
+                            config.save();
+                            selected = 1;
                             continue;
                         }
                         2 => {
-                            let result = run_server_connect(&mut *config, false, &mut reader).await;
-                            match result {
-                                ServerConnectResult::Selected(addr) => {
-                                    config.push_recent_server(&addr);
-                                    let join_result = run_join_room(&addr, &mut reader).await;
-                                    match join_result {
-                                        JoinRoomResult::Joined(code) => {
-                                            return MenuAction::Join {
-                                                relay_addr: addr,
-                                                room_code: code,
-                                            };
-                                        }
-                                        JoinRoomResult::Back => {
-                                            selected = 2;
-                                        }
-                                    }
-                                    continue;
-                                }
-                                ServerConnectResult::Back => {
-                                    selected = 2;
-                                }
-                            }
+                            run_join_flow(config, &mut reader).await;
+                            config.save();
+                            selected = 2;
                             continue;
                         }
                         3 => {
@@ -98,10 +66,10 @@ pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
                             selected = 0;
                             continue;
                         }
-                        4 => return MenuAction::Quit,
+                        4 => return,
                         _ => {}
                     },
-                    KeyCode::Char('q') | KeyCode::Esc => return MenuAction::Quit,
+                    KeyCode::Char('q') | KeyCode::Esc => return,
                     _ => {}
                 }
             }
@@ -126,6 +94,52 @@ pub async fn menu_loop(config: &mut AppConfig) -> MenuAction {
                     }
                 }
             }
+        }
+    }
+}
+
+/// Run the host flow: server connect → game session. Loops back to
+/// server connect after the session ends (disconnect, error, etc).
+async fn run_host_flow(config: &mut AppConfig, reader: &mut EventStream) {
+    loop {
+        let result = run_server_connect(config, true, reader).await;
+        match result {
+            ServerConnectResult::Selected(addr) => {
+                config.push_recent_server(&addr);
+                crate::run_host(config, &addr).await;
+                // Recreate reader after game (old one is stale)
+                *reader = EventStream::new();
+                // Loop back to server connect
+            }
+            ServerConnectResult::Back => return,
+        }
+    }
+}
+
+/// Run the join flow: server connect → room code → game session. Loops
+/// back to room code after the session ends. Loops back to server
+/// connect if the user presses Back from the room code screen.
+async fn run_join_flow(config: &mut AppConfig, reader: &mut EventStream) {
+    loop {
+        let result = run_server_connect(config, false, reader).await;
+        match result {
+            ServerConnectResult::Selected(addr) => {
+                config.push_recent_server(&addr);
+                // Loop on the room code screen — retries come back here
+                loop {
+                    let join_result = run_join_room(&addr, reader).await;
+                    match join_result {
+                        JoinRoomResult::Joined { conn, room_code } => {
+                            crate::run_join(conn, &room_code).await;
+                            // Recreate reader after game
+                            *reader = EventStream::new();
+                            // Loop back to room code screen
+                        }
+                        JoinRoomResult::Back => break, // back to server connect
+                    }
+                }
+            }
+            ServerConnectResult::Back => return,
         }
     }
 }
@@ -534,7 +548,10 @@ pub async fn run_settings_inline(config: &mut AppConfig, reader: &mut EventStrea
 // ─── Join room ──────────────────────────────────────────────────────
 
 enum JoinRoomResult {
-    Joined(String),
+    Joined {
+        conn: crate::net::NetConnection,
+        room_code: String,
+    },
     Back,
 }
 
@@ -542,20 +559,24 @@ async fn run_join_room(relay_addr: &str, reader: &mut EventStream) -> JoinRoomRe
     let mut input_buf = String::new();
     let mut editing = true;
     let mut selected: usize = 0; // 0 = text input, 1 = Back
+    let mut error_msg: Option<String> = None;
 
     loop {
         let term_size = render::terminal_size();
         let title_text = format!("JOIN — {}", relay_addr);
 
-        let items = [
-            MenuItem::TextInput {
-                label: "Room Code:",
-                value: &input_buf,
-                editing: editing && selected == 0,
-            },
-            MenuItem::Label(""),
-            MenuItem::Action("Back"),
-        ];
+        let mut items: Vec<MenuItem> = vec![MenuItem::TextInput {
+            label: "Room Code:",
+            value: &input_buf,
+            editing: editing && selected == 0,
+        }];
+
+        if let Some(ref err) = error_msg {
+            items.push(MenuItem::Error(err));
+        }
+
+        items.push(MenuItem::Label(""));
+        items.push(MenuItem::Action("Back"));
 
         render::render_menu(&title_text, &items, selected, term_size);
 
@@ -568,22 +589,41 @@ async fn run_join_room(relay_addr: &str, reader: &mut EventStream) -> JoinRoomRe
                 match key.code {
                     KeyCode::Enter => {
                         let code = input_buf.trim().to_uppercase();
-                        if !code.is_empty() {
-                            return JoinRoomResult::Joined(code);
+                        if code.is_empty() {
+                            continue;
                         }
-                        editing = false;
+                        // Show a connecting message
+                        let connecting_msg = format!("Connecting to {}...", relay_addr);
+                        render::render_message(&connecting_msg, term_size);
+
+                        match crate::lobby::try_join_room(relay_addr, &code).await {
+                            Ok(conn) => {
+                                return JoinRoomResult::Joined {
+                                    conn,
+                                    room_code: code,
+                                };
+                            }
+                            Err(e) => {
+                                error_msg = Some(format!("{}", e));
+                                input_buf.clear();
+                            }
+                        }
                     }
                     KeyCode::Esc => {
                         editing = false;
+                        error_msg = None;
                     }
                     KeyCode::Backspace => {
                         input_buf.pop();
+                        error_msg = None;
                     }
                     KeyCode::Char(c) => {
                         input_buf.push(c);
+                        error_msg = None;
                     }
                     KeyCode::Down | KeyCode::Tab => {
                         editing = false;
+                        error_msg = None;
                         selected = 1;
                     }
                     _ => {}

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -561,16 +561,6 @@ pub fn render_joined_room(room_code: &str, term_size: (u16, u16)) {
     render_centered_box(&lines, term_size, Blue);
 }
 
-pub fn render_role_select(term_size: (u16, u16)) {
-    let lines = [
-        "CHOOSE YOUR ROLE",
-        "",
-        "[V] Viewer — See words, give clues",
-        "[H] Holder — Guess and press Y/N",
-    ];
-    render_centered_box(&lines, term_size, Blue);
-}
-
 pub fn render_role_assigned(role: Role, term_size: (u16, u16)) {
     let role_line = format!("You are the: {}", role);
     let desc = match role {

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -10,6 +10,228 @@ use protocol::Role;
 use std::io::{stdout, Write};
 use std::time::Duration;
 
+// ─── Menu rendering ─────────────────────────────────────────────────
+
+pub enum MenuItem<'a> {
+    Label(&'a str),
+    Action(&'a str),
+    Setting {
+        label: &'a str,
+        value: &'a str,
+    },
+    TextInput {
+        label: &'a str,
+        value: &'a str,
+        editing: bool,
+    },
+}
+
+impl MenuItem<'_> {
+    pub fn is_selectable(&self) -> bool {
+        !matches!(self, MenuItem::Label(_))
+    }
+}
+
+pub fn render_menu(title: &str, items: &[MenuItem], selected: usize, term_size: (u16, u16)) {
+    let (tw, th) = term_size;
+
+    // Calculate content width from items
+    let item_widths: Vec<usize> = items
+        .iter()
+        .map(|item| match item {
+            MenuItem::Label(s) | MenuItem::Action(s) => s.len(),
+            MenuItem::Setting { label, value } => label.len() + value.len() + 4,
+            MenuItem::TextInput {
+                label,
+                value,
+                editing,
+            } => {
+                let cursor = if *editing { "_" } else { "" };
+                label.len() + value.len() + cursor.len() + 4
+            }
+        })
+        .collect();
+
+    let content_width = title.len().max(*item_widths.iter().max().unwrap_or(&20)) + 6; // "│ " + content + " │" + padding
+
+    let box_line: String = "―".repeat(content_width - 2);
+    let total_height = items.len() as u16 + 4; // top border + title + blank + items + bottom border
+    let start_row = th.saturating_sub(total_height) / 2;
+    let col = center_col(tw, content_width as u16);
+
+    let _ = queue!(
+        stdout(),
+        SetColors(Colors::new(White, Blue)),
+        Clear(terminal::ClearType::All),
+        MoveTo(col, start_row),
+    );
+    print!("┌{}┐", box_line);
+
+    // Title
+    let _ = queue!(stdout(), MoveTo(col, start_row + 1));
+    let _ = queue!(stdout(), SetColors(Colors::new(DarkYellow, Blue)));
+    print!("│ {:^width$} │", title, width = content_width - 4);
+
+    // Blank line under title
+    let _ = queue!(stdout(), MoveTo(col, start_row + 2));
+    let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+    print!("│ {:width$} │", "", width = content_width - 4);
+
+    // Track which selectable index we're at
+    let mut selectable_idx = 0;
+
+    for (i, item) in items.iter().enumerate() {
+        let row = start_row + 3 + i as u16;
+        let _ = queue!(stdout(), MoveTo(col, row));
+
+        let is_selected = item.is_selectable() && selectable_idx == selected;
+        if item.is_selectable() {
+            selectable_idx += 1;
+        }
+
+        if is_selected {
+            let _ = queue!(stdout(), SetColors(Colors::new(DarkYellow, Black)));
+        } else {
+            let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+        }
+
+        let text = match item {
+            MenuItem::Label(s) => format!("  {}", s),
+            MenuItem::Action(s) => {
+                if is_selected {
+                    format!("> {}", s)
+                } else {
+                    format!("  {}", s)
+                }
+            }
+            MenuItem::Setting { label, value } => {
+                if is_selected {
+                    format!("> {}  {}", label, value)
+                } else {
+                    format!("  {}  {}", label, value)
+                }
+            }
+            MenuItem::TextInput {
+                label,
+                value,
+                editing,
+            } => {
+                let display_val = if *editing {
+                    format!("{}_", value)
+                } else {
+                    value.to_string()
+                };
+                if is_selected {
+                    format!("> {}  {}", label, display_val)
+                } else {
+                    format!("  {}  {}", label, display_val)
+                }
+            }
+        };
+
+        print!("│ {:<width$} │", text, width = content_width - 4);
+
+        // Reset colors after selected item
+        if is_selected {
+            let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+        }
+    }
+
+    // Bottom border
+    let bottom_row = start_row + 3 + items.len() as u16;
+    let _ = queue!(stdout(), MoveTo(col, bottom_row));
+    let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+    print!("└{}┘", box_line);
+
+    let _ = stdout().flush();
+}
+
+pub fn render_category_picker(
+    categories: &[String],
+    selected: usize,
+    scroll_offset: usize,
+    term_size: (u16, u16),
+) {
+    let (tw, th) = term_size;
+    let visible_count = 15usize.min(categories.len());
+    let content_width = categories
+        .iter()
+        .map(|c| c.len())
+        .max()
+        .unwrap_or(10)
+        .max("SELECT CATEGORY".len())
+        + 6;
+
+    let box_line: String = "―".repeat(content_width - 2);
+    let total_height = visible_count as u16 + 4; // borders + title + blank
+    let start_row = th.saturating_sub(total_height) / 2;
+    let col = center_col(tw, content_width as u16);
+
+    let _ = queue!(
+        stdout(),
+        SetColors(Colors::new(White, Blue)),
+        Clear(terminal::ClearType::All),
+        MoveTo(col, start_row),
+    );
+    print!("┌{}┐", box_line);
+
+    // Title
+    let _ = queue!(stdout(), MoveTo(col, start_row + 1));
+    let _ = queue!(stdout(), SetColors(Colors::new(DarkYellow, Blue)));
+    print!(
+        "│ {:^width$} │",
+        "SELECT CATEGORY",
+        width = content_width - 4
+    );
+
+    // Scroll indicator top
+    let _ = queue!(stdout(), MoveTo(col, start_row + 2));
+    let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+    if scroll_offset > 0 {
+        print!("│ {:^width$} │", "▲ more ▲", width = content_width - 4);
+    } else {
+        print!("│ {:width$} │", "", width = content_width - 4);
+    }
+
+    // Visible items
+    for i in 0..visible_count {
+        let idx = scroll_offset + i;
+        let row = start_row + 3 + i as u16;
+        let _ = queue!(stdout(), MoveTo(col, row));
+
+        let is_selected = idx == selected;
+        if is_selected {
+            let _ = queue!(stdout(), SetColors(Colors::new(DarkYellow, Black)));
+        } else {
+            let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+        }
+
+        let prefix = if is_selected { "> " } else { "  " };
+        let name = &categories[idx];
+        print!("│ {}{:<width$} │", prefix, name, width = content_width - 6);
+
+        if is_selected {
+            let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+        }
+    }
+
+    // Scroll indicator bottom
+    let bottom_indicator_row = start_row + 3 + visible_count as u16;
+    let _ = queue!(stdout(), MoveTo(col, bottom_indicator_row));
+    let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
+    if scroll_offset + visible_count < categories.len() {
+        print!("│ {:^width$} │", "▼ more ▼", width = content_width - 4);
+    } else {
+        print!("│ {:width$} │", "", width = content_width - 4);
+    }
+
+    // Bottom border
+    let _ = queue!(stdout(), MoveTo(col, bottom_indicator_row + 1));
+    print!("└{}┘", box_line);
+
+    let _ = stdout().flush();
+}
+
 pub struct TerminalGuard;
 
 impl TerminalGuard {

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -24,11 +24,12 @@ pub enum MenuItem<'a> {
         value: &'a str,
         editing: bool,
     },
+    Error(&'a str),
 }
 
 impl MenuItem<'_> {
     pub fn is_selectable(&self) -> bool {
-        !matches!(self, MenuItem::Label(_))
+        !matches!(self, MenuItem::Label(_) | MenuItem::Error(_))
     }
 }
 
@@ -39,7 +40,7 @@ pub fn render_menu(title: &str, items: &[MenuItem], selected: usize, term_size: 
     let item_widths: Vec<usize> = items
         .iter()
         .map(|item| match item {
-            MenuItem::Label(s) | MenuItem::Action(s) => s.len(),
+            MenuItem::Label(s) | MenuItem::Action(s) | MenuItem::Error(s) => s.len(),
             MenuItem::Setting { label, value } => label.len() + value.len() + 4,
             MenuItem::TextInput {
                 label,
@@ -89,14 +90,16 @@ pub fn render_menu(title: &str, items: &[MenuItem], selected: usize, term_size: 
             selectable_idx += 1;
         }
 
-        if is_selected {
+        if matches!(item, MenuItem::Error(_)) {
+            let _ = queue!(stdout(), SetColors(Colors::new(Red, Blue)));
+        } else if is_selected {
             let _ = queue!(stdout(), SetColors(Colors::new(DarkYellow, Black)));
         } else {
             let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
         }
 
         let text = match item {
-            MenuItem::Label(s) => format!("  {}", s),
+            MenuItem::Label(s) | MenuItem::Error(s) => format!("  {}", s),
             MenuItem::Action(s) => {
                 if is_selected {
                     format!("> {}", s)
@@ -131,8 +134,8 @@ pub fn render_menu(title: &str, items: &[MenuItem], selected: usize, term_size: 
 
         print!("│ {:<width$} │", text, width = content_width - 4);
 
-        // Reset colors after selected item
-        if is_selected {
+        // Reset colors after highlighted items
+        if is_selected || matches!(item, MenuItem::Error(_)) {
             let _ = queue!(stdout(), SetColors(Colors::new(White, Blue)));
         }
     }
@@ -599,4 +602,9 @@ pub fn render_post_game_menu(term_size: (u16, u16)) {
 pub fn render_message(msg: &str, term_size: (u16, u16)) {
     let lines = [msg];
     render_centered_box(&lines, term_size, Blue);
+}
+
+pub fn render_error(msg: &str, term_size: (u16, u16)) {
+    let lines = ["ERROR", "", msg, "", "Press any key to continue..."];
+    render_centered_box(&lines, term_size, Red);
 }

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -537,18 +537,6 @@ fn render_centered_box(lines: &[&str], term_size: (u16, u16), bg: Color) {
     let _ = stdout().flush();
 }
 
-pub fn render_waiting_for_peer(room_code: &str, term_size: (u16, u16)) {
-    let code_line = format!("Room: {}", room_code);
-    let lines = [
-        "HEADS UP — HOST",
-        "",
-        &code_line,
-        "",
-        "Waiting for opponent...",
-    ];
-    render_centered_box(&lines, term_size, Blue);
-}
-
 pub fn render_joined_room(room_code: &str, term_size: (u16, u16)) {
     let code_line = format!("Joined room: {}", room_code);
     let lines = [


### PR DESCRIPTION
## Summary

- Remove clap dependency from the client and replace all CLI flags with an interactive TUI menu system (arrow/hjkl navigation, Enter to select, Esc to go back)
- Settings persist between sessions via `~/.heads_up_config.json` — game time, categories, extra-time mode, word file, recent relay servers
- Settings accessible from the main menu, host server connect screen, host lobby (waiting for peer), and role selection screen
- Relay server addresses validated inline (must be `host:port` with numeric port 1-65535) — errors shown in red on the input screen
- Room code errors (wrong code, connection refused) shown inline on the room code page so the user can retry without navigating back
- Connection errors shown in a TUI error screen with press-any-key prompt instead of ephemeral stderr output
- Room stays alive across games — both host and joiner recover the TCP connection after each game for multi-round play (PlayAgain / SwapRoles / Quit)
- After a game ends, players stay in the lobby flow (server connect / room code screens) instead of returning to the main menu

### New modules
- `config.rs` — `AppConfig` with serde defaults, load/save, `to_game_config()` conversion
- `menu.rs` — Menu state machine with screens: Main, Settings, CategoryPicker, ServerConnect, JoinRoom

## Test plan

- [x] `cargo run -p guess_up` — main menu renders, hjkl/arrow navigation works
- [x] Settings screen: change game time with left/right, toggle booleans with Enter, category picker scrolls
- [x] Settings persist: change a value, quit, re-launch — value is preserved
- [x] Solo game: plays full game, shows summary, returns to main menu
- [x] Host: server connect validates address (try `badaddr` — error shown inline)
- [x] Host: lobby shows room code + Settings/Disconnect options while waiting
- [x] Host: settings accessible from role selection screen
- [x] Join: wrong room code shows error inline, correct code joins
- [x] Networked: PlayAgain and SwapRoles work across multiple rounds without reconnecting
- [x] Networked: joiner presses Q while waiting to quit gracefully
- [x] Networked: peer disconnect handled cleanly on both sides
- [x] After host/join game ends, stays in lobby flow (not main menu)
- [ ] Terminal restores cleanly on Ctrl+C


🤖 Generated with [Claude Code](https://claude.com/claude-code)