### PR TITLE
Fix timer display bugs and add universal Ctrl+C

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,14 +8,14 @@
 - [ ] Fix timer skipping first second — timer often jumps from e.g. 10 to 8 on the first tick, and bonus time additions are inconsistent
 - [ ] Fix viewer side screen flash — flash effect not displaying correctly on the joiner/viewer side in networked mode
 - [ ] Custom word list support — allow users to create/import their own themed word lists beyond ASOIAF
-- [ ] Universal Ctrl+C — allow Ctrl+C to break out of the terminal at any point during the game
-- [ ] Rename config to `guess_up_config` — the configuration file should be named `guess_up_config` instead of the current name
+- [x] Universal Ctrl+C — allow Ctrl+C to break out of the terminal at any point during the game
+- [x] Rename config to `guess_up_config` — the configuration file should be named `guess_up_config` instead of the current name
 
 ## Medium
 
 - [ ] Add color scheme option — starting schemes: grayscale, pastel, beige, blue
-- [ ] Return to lobby after game ends instead of exiting — show stats screen in-TUI, then back to menu
-- [ ] Replace clap with TUI menu system ([plan](.claude/tui-menu-plan.md))
+- [x] Return to lobby after game ends instead of exiting — show stats screen in-TUI, then back to menu
+- [x] Replace clap with TUI menu system ([plan](.claude/tui-menu-plan.md))
 - [ ] Print game summary to all players — show end-of-game stats (score, words guessed/skipped) to both host and joiner in networked mode
 - [ ] Round-based multiplayer — multiple rounds with automatic role swapping and cumulative scoring
 - [ ] Spawn a terminal when executable is run outside of one (e.g. double-clicked from file manager)

--- a/crates/client/src/input.rs
+++ b/crates/client/src/input.rs
@@ -1,6 +1,10 @@
 use crate::types::{EventSender, GameEvent, UserAction};
-use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use futures::StreamExt;
+
+pub fn is_ctrl_c(key: &KeyEvent) -> bool {
+    key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL)
+}
 
 pub async fn input_task(tx: EventSender) {
     let mut reader = EventStream::new();
@@ -10,6 +14,9 @@ pub async fn input_task(tx: EventSender) {
             // Only handle key press events (not release/repeat)
             if key.kind != KeyEventKind::Press {
                 continue;
+            }
+            if is_ctrl_c(&key) {
+                crate::render::force_exit();
             }
             let action = match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => Some(UserAction::Correct),

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -177,6 +177,9 @@ async fn wait_for_peer(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
+                if crate::input::is_ctrl_c(&key) {
+                    crate::render::force_exit();
+                }
                 match key.code {
                     KeyCode::Up | KeyCode::Char('k') => {
                         selected = selected.checked_sub(1).unwrap_or(count - 1);
@@ -317,6 +320,9 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
                 tokio::select! {
                     event = reader.next() => {
                         if let Some(Ok(Event::Key(key))) = event {
+                            if key.kind == KeyEventKind::Press && crate::input::is_ctrl_c(&key) {
+                                crate::render::force_exit();
+                            }
                             if key.kind == KeyEventKind::Press
                                 && matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc)
                             {
@@ -453,6 +459,9 @@ async fn select_role(app_config: &mut AppConfig) -> Role {
         if key.kind != KeyEventKind::Press {
             continue;
         }
+        if crate::input::is_ctrl_c(&key) {
+            crate::render::force_exit();
+        }
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
                 selected = selected.checked_sub(1).unwrap_or(count - 1);
@@ -492,6 +501,9 @@ async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameActi
                 if let Some(Ok(Event::Key(key))) = event {
                     if key.kind != KeyEventKind::Press {
                         continue;
+                    }
+                    if crate::input::is_ctrl_c(&key) {
+                        crate::render::force_exit();
                     }
                     match key.code {
                         KeyCode::Char('p') | KeyCode::Char('P') => {

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -155,6 +155,9 @@ pub async fn show_error(msg: &str) {
     while let Some(Ok(event)) = reader.next().await {
         if let Event::Key(key) = event {
             if key.kind == KeyEventKind::Press {
+                if input::is_ctrl_c(&key) {
+                    render::force_exit();
+                }
                 break;
             }
         }

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -39,6 +39,9 @@ pub async fn menu_loop(config: &mut AppConfig) {
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
+                if crate::input::is_ctrl_c(&key) {
+                    crate::render::force_exit();
+                }
                 match key.code {
                     KeyCode::Up | KeyCode::Char('k') => {
                         selected = selected.checked_sub(1).unwrap_or(count - 1);
@@ -258,6 +261,9 @@ async fn run_settings_screen(
         if key.kind != KeyEventKind::Press {
             return SettingsResult::Continue;
         }
+        if crate::input::is_ctrl_c(&key) {
+            crate::render::force_exit();
+        }
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
                 *selected = selected.checked_sub(1).unwrap_or(SETTINGS_COUNT - 1);
@@ -358,6 +364,9 @@ async fn run_category_picker(
         if let Some(Ok(Event::Key(key))) = reader.next().await {
             if key.kind != KeyEventKind::Press {
                 continue;
+            }
+            if crate::input::is_ctrl_c(&key) {
+                crate::render::force_exit();
             }
             match key.code {
                 KeyCode::Up | KeyCode::Char('k') => {
@@ -468,6 +477,9 @@ async fn run_server_connect(
         if let Some(Ok(Event::Key(key))) = reader.next().await {
             if key.kind != KeyEventKind::Press {
                 continue;
+            }
+            if crate::input::is_ctrl_c(&key) {
+                crate::render::force_exit();
             }
 
             // If we're editing text input
@@ -602,6 +614,9 @@ async fn run_join_room(relay_addr: &str, reader: &mut EventStream) -> JoinRoomRe
             if key.kind != KeyEventKind::Press {
                 continue;
             }
+            if crate::input::is_ctrl_c(&key) {
+                crate::render::force_exit();
+            }
 
             if editing && selected == 0 {
                 match key.code {
@@ -693,6 +708,9 @@ async fn run_text_input(prompt: &str, initial: &str, reader: &mut EventStream) -
         if let Some(Ok(Event::Key(key))) = reader.next().await {
             if key.kind != KeyEventKind::Press {
                 continue;
+            }
+            if crate::input::is_ctrl_c(&key) {
+                crate::render::force_exit();
             }
             match key.code {
                 KeyCode::Enter => return Some(buf),

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -260,6 +260,13 @@ impl Drop for TerminalGuard {
     }
 }
 
+/// Immediately exit the process, restoring terminal state first.
+pub fn force_exit() -> ! {
+    let _ = execute!(stdout(), Show, LeaveAlternateScreen);
+    let _ = terminal::disable_raw_mode();
+    std::process::exit(0);
+}
+
 pub fn terminal_size() -> (u16, u16) {
     terminal::size().unwrap_or((80, 24))
 }

--- a/crates/client/src/timer.rs
+++ b/crates/client/src/timer.rs
@@ -11,16 +11,26 @@ pub async fn timer_task(tx: EventSender, duration: u64, mut bonus_rx: BonusRecei
     loop {
         tokio::select! {
             _ = interval.tick() => {
+                // Apply any pending bonus time before computing remaining
+                while let Ok(bonus) = bonus_rx.try_recv() {
+                    deadline += Duration::from_secs(bonus);
+                }
                 let now = Instant::now();
                 if now >= deadline {
                     let _ = tx.send(GameEvent::TimerExpired).await;
                     break;
                 }
-                let remaining = (deadline - now).as_secs();
+                let remaining = (deadline - now).as_secs_f64().ceil() as u64;
                 let _ = tx.send(GameEvent::TimerTick(remaining)).await;
             }
             Some(bonus) = bonus_rx.recv() => {
                 deadline += Duration::from_secs(bonus);
+                // Immediately display updated time so the full bonus is visible
+                let now = Instant::now();
+                if now < deadline {
+                    let remaining = (deadline - now).as_secs_f64().ceil() as u64;
+                    let _ = tx.send(GameEvent::TimerTick(remaining)).await;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Timer first-second skip**: remaining-seconds used truncating `as_secs()` which could skip a displayed second (e.g. 10 → 8). Switched to ceiling so the value doesn't drop until the full second elapses.
- **Bonus time display**: bonus time additions now drain pending bonuses before computing remaining and send an immediate `TimerTick` when received, so the full bonus is visible right away (4 + 2 → 6 → 5) instead of appearing to lose a second (4 → 5 → 4).
- **Universal Ctrl+C**: added `force_exit()` (restores terminal state and exits) and `is_ctrl_c()` helper, wired into every keyboard input point — game loop, all menu screens, lobby screens, and error display.
- **TODO cleanup**: marked items completed in prior PRs (TUI menu, return to lobby, config rename).

## Test plan
- [x] Solo game: verify timer counts down without skipping the first second
- [x] Extra-time mode: verify bonus seconds display the full amount immediately (e.g. 4s + 2s bonus → shows 6)
- [x] Press Ctrl+C during a game — exits cleanly, terminal restored
- [x] Press Ctrl+C in main menu, settings, server connect, room code, lobby — exits cleanly from each
- [x] Normal gameplay (y/n/q, menus, navigation) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)