### PR TITLE
Multi-viewer support: 1 host + up to 8 joiners

### DIFF
--- a/.claude/multi-viewer-plan.md
+++ b/.claude/multi-viewer-plan.md
@@ -1,0 +1,363 @@
+# Multi-Viewer Support Plan
+
+## Context
+
+Currently, networked games support exactly 2 peers (1 host + 1 joiner). The relay server has a single `joiner_tx: Option<Sender>` per room, and the client assumes a 1:1 relationship everywhere. This plan extends networked mode to support **1 host + up to 8 joiners** in a single room, enabling the party game experience where multiple people see the word and give clues while one person guesses.
+
+**Key design decisions:**
+- Extend existing networked mode (not a separate mode) -- any room supports 1-8 joiners
+- Host picks who the Holder is from a participant list (can be themselves or any joiner)
+- Between rounds, host picks the next Holder (enables rotation)
+- Spectator mode (separate TODO item) is removed from the TODO list
+
+---
+
+## Phase 1: Protocol Changes (`crates/protocol/src/lib.rs`)
+
+Add a PeerId type and update all message enums. Host is always PeerId 0, joiners get 1, 2, 3, etc. assigned by the relay.
+
+**Add:**
+```rust
+pub type PeerId = u8;
+pub const HOST_PEER_ID: PeerId = 0;
+```
+
+**`ClientMessage`** -- change `GameData` from tuple to struct variant with optional target:
+```rust
+pub enum ClientMessage {
+    CreateRoom,
+    JoinRoom { code: String },
+    GameData { msg: GameMessage, target: Option<PeerId> }, // None = broadcast (host) or send to host (joiner)
+    Disconnect,
+    Pong,
+}
+```
+
+**`RelayMessage`** -- add peer IDs and a peer list message:
+```rust
+pub enum RelayMessage {
+    RoomCreated { code: String },
+    PeerJoined { peer_id: PeerId },           // was unit variant
+    JoinedRoom { peer_id: PeerId },           // was unit variant; tells joiner their ID
+    PeerList { peers: Vec<PeerId> },          // NEW: sent to new joiner (who's already here)
+    GameData { msg: GameMessage, from: PeerId }, // was tuple; now carries sender ID
+    PeerDisconnected { peer_id: PeerId },     // was unit variant
+    Error(RelayError),
+    Ping,
+}
+```
+
+**`GameMessage`** -- update role assignment and post-game actions:
+```rust
+// Change:
+RoleAssignment { host_role: Role }  -->  RoleAssignment { holder_id: PeerId }
+// Each recipient computes their own role: holder_id == my_id ? Holder : Viewer
+
+// Remove:
+SwapRoles  // no longer meaningful with N players
+
+// Add:
+PickNextHolder  // host signals a new holder selection round
+```
+
+---
+
+## Phase 2: Relay Server (`crates/relay/src/main.rs`)
+
+### 2a. Room struct
+
+```rust
+struct Peer {
+    tx: mpsc::Sender<RelayMessage>,
+    peer_id: PeerId,
+}
+
+struct Room {
+    host_tx: mpsc::Sender<RelayMessage>,
+    peers: Vec<Peer>,         // was: joiner_tx: Option<Sender>
+    next_peer_id: PeerId,     // starts at 1, increments monotonically (never reuses IDs)
+    created_at: Instant,
+}
+```
+
+Add helper methods on `Room`:
+- `broadcast_to_peers(&self, msg, exclude: Option<PeerId>)` -- send to all peers, optionally excluding one
+- `send_to_peer(&self, peer_id, msg) -> bool` -- send to a specific peer
+- `remove_peer(&mut self, peer_id)` -- remove a peer from the vec
+
+### 2b. `create_room()` 
+Initialize `peers: Vec::new()`, `next_peer_id: 1`. No other changes.
+
+### 2c. `join_room()`
+- Check `peers.len() < 8` (was `joiner_tx.is_some()`)
+- Assign `peer_id = next_peer_id; next_peer_id += 1`
+- Push `Peer { tx, peer_id }` onto `peers`
+- Send `PeerJoined { peer_id }` to the host AND all existing peers
+- Return `(Arc<Mutex<Room>>, peer_id)` so the handler can send `JoinedRoom` and `PeerList`
+
+### 2d. `handle_host()` -- major rewrite
+The current code blocks waiting for exactly one `PeerJoined` before entering `run_forwarding`. Replace with an immediate main loop:
+
+1. Create room, send `RoomCreated` to host
+2. Enter select loop immediately (no waiting for first joiner):
+   - `rx.recv()` -> write to host TCP (PeerJoined notifications come through here)
+   - `read_frame` from host TCP:
+     - `GameData { msg, target: None }` -> lock room, broadcast to all peers
+     - `GameData { msg, target: Some(id) }` -> lock room, send to that specific peer
+     - `Disconnect` -> notify all peers with `PeerDisconnected { peer_id: 0 }`, remove room, break
+   - `ping_interval` -> send Ping
+
+The host handler needs `Arc<Mutex<Room>>` to access the peer list for broadcasting.
+
+### 2e. `handle_joiner()` -- moderate rewrite
+1. `join_room()` returns `(room, peer_id)`
+2. Send `JoinedRoom { peer_id }` and `PeerList { peers }` to the joiner
+3. Enter select loop:
+   - `rx.recv()` -> write to joiner TCP
+   - `read_frame` from joiner TCP:
+     - `GameData { msg, .. }` -> send to `host_tx` as `RelayMessage::GameData { msg, from: peer_id }`
+     - `Disconnect` -> remove peer from room, notify host + remaining peers, break
+   - `ping_interval` -> send Ping
+4. On joiner disconnect: remove peer, notify others. Room stays alive.
+
+### 2f. `run_forwarding()` -- removed
+Replaced by the separate host/joiner loops above. The asymmetric routing (host broadcasts, joiner sends to host) makes a shared function awkward.
+
+### 2g. Room lifecycle changes
+- Only host disconnect removes the room (currently either peer removes it)
+- Joiner disconnect: remove from `peers`, notify host + remaining peers
+- `reap_stale_rooms()`: no changes needed
+
+---
+
+## Phase 3: Client Net Layer (`crates/client/src/net.rs`, `crates/client/src/types.rs`)
+
+### 3a. Outbound message enum (`net.rs`)
+```rust
+pub enum OutboundMsg {
+    Broadcast(GameMessage),
+    SendTo(PeerId, GameMessage),
+}
+```
+
+Change `NetHandle::outbound_tx` from `mpsc::Sender<GameMessage>` to `mpsc::Sender<OutboundMsg>`.
+
+### 3b. `net_write_task()` 
+Map `OutboundMsg::Broadcast(msg)` to `ClientMessage::GameData { msg, target: None }` and `OutboundMsg::SendTo(id, msg)` to `ClientMessage::GameData { msg, target: Some(id) }`.
+
+### 3c. `net_read_task()` / `translate_game_message()`
+Handle new `RelayMessage` variants:
+- `GameData { msg, from }` -> translate `msg` as before; for `PlayerInput`, produce `GameEvent::RemoteInput(from, action)` with the `from` peer ID (see types changes below)
+- `PeerJoined { peer_id }` -> `GameEvent::PeerJoined(peer_id)`
+- `PeerDisconnected { peer_id }` -> `GameEvent::PeerDisconnected(peer_id)`
+- `PeerList { peers }` -> `GameEvent::PeerList(peers)`
+
+### 3d. GameEvent changes (`types.rs`)
+```rust
+pub enum GameEvent {
+    // Existing
+    UserInput(UserAction),
+    TimerTick(u64),
+    TimerExpired,
+    Redraw,
+
+    // Network -- updated with PeerId
+    RemoteInput(PeerId, UserAction),    // was RemoteInput(UserAction)
+    NetWordUpdate(String),
+    NetTimerSync(u64),
+    NetScoreUpdate { score: usize, total: usize },
+    NetFlash(FlashKind),
+    NetTimerExpired,
+    NetGameOver(NetGameResult),
+    PeerDisconnected(PeerId),           // was PeerDisconnected (unit)
+
+    // New
+    PeerJoined(PeerId),
+    PeerList(Vec<PeerId>),
+}
+```
+
+---
+
+## Phase 4: Client Lobby (`crates/client/src/lobby.rs`)
+
+### 4a. `wait_for_peer()` -> `wait_for_players()`
+Replace the current function that returns `bool` on first PeerJoined. New behavior:
+- Renders a live lobby showing room code, connected player count, and player list
+- Accumulates `Vec<PeerId>` as `PeerJoined` events arrive
+- Removes peers on `PeerDisconnected`
+- Shows "Start Game" action (enabled when >= 1 joiner present) and "Settings" / "Disconnect"
+- Returns `Some(Vec<PeerId>)` when host presses Start, or `None` on disconnect
+
+```
+          HOST LOBBY
+
+      Room: ABCDE
+
+      Players: 3/9
+        Host (you)
+        Player 1
+        Player 2
+
+      > Start Game
+        Settings
+        Disconnect
+```
+
+### 4b. `select_role()` -> `select_holder()`
+Replace the Viewer/Holder binary choice with a participant picker:
+- Lists all participants: "Host (you)" + "Player N" for each joiner PeerId
+- Host navigates and selects who will be the Holder
+- Returns `PeerId` (0 for host, or the joiner's ID)
+
+```
+      CHOOSE THE HOLDER
+
+      > Host (you)
+        Player 1
+        Player 2
+
+        Settings
+```
+
+### 4c. `run_host_session()` changes
+Update the main game loop:
+1. `wait_for_players()` -> get participant list
+2. `select_holder()` -> get holder PeerId
+3. Broadcast `RoleAssignment { holder_id }` to all joiners (via `Broadcast`)
+4. Wait for `RoleAccepted` from all joiners (track `HashSet<PeerId>`)
+5. Broadcast `GameStart(net_config)`
+6. Run game via `run_host_game()` (pass `holder_peer_id`)
+7. Post-game: replace `PostGameAction::SwapRoles` with `PostGameAction::PickNextHolder`
+
+The `RoleAssignment` is broadcast to all. Each joiner computes: `if holder_id == my_id { Holder } else { Viewer }`.
+
+### 4d. `run_host_game()` changes
+Pass `holder_peer_id: Option<PeerId>` through to `run_game()`. If host is the Holder, `holder_peer_id` is `None` (process local input). If a joiner is the Holder, `holder_peer_id` is `Some(id)`.
+
+### 4e. Post-game menu
+Replace `SwapRoles` option:
+```rust
+enum PostGameAction {
+    PlayAgain,       // same holder
+    PickNextHolder,  // return to holder selection screen
+    Quit,
+}
+```
+- "Play Again (same holder)" -> send `PlayAgain` broadcast, loop back to game
+- "Pick Next Holder" -> send `PickNextHolder` broadcast, loop back to `select_holder()`
+- "Quit" -> send `QuitSession` broadcast
+
+### 4f. `run_joiner_session()` changes
+- Store `my_id: PeerId` from `JoinedRoom { peer_id }` response
+- On `RoleAssignment { holder_id }`: compute role as `if holder_id == my_id { Holder } else { Viewer }`
+- On `PeerDisconnected(0)` (host): show "Host disconnected", exit
+- On `PeerDisconnected(other)`: ignore (host handles participant management)
+- Between rounds: wait for next `RoleAssignment` (same as today)
+
+### 4g. `try_join_room()` changes
+Parse `JoinedRoom { peer_id }` instead of unit `JoinedRoom`. Return `(NetConnection, PeerId)`.
+
+---
+
+## Phase 5: Game Loop (`crates/client/src/game.rs`)
+
+### 5a. `run_game()` signature
+Add `holder_peer_id: Option<PeerId>` parameter. This identifies which remote peer is the Holder (None if host is Holder or solo mode).
+
+### 5b. Input routing
+Update the match in `run_game()`:
+```rust
+let should_process = match (local_role, &event) {
+    (None, GameEvent::UserInput(_)) => true,                           // Solo
+    (Some(Role::Viewer), GameEvent::RemoteInput(pid, _))
+        if Some(*pid) == holder_peer_id => true,                       // Remote holder's input
+    (Some(Role::Holder), GameEvent::UserInput(_)) => true,             // Local holder's input
+    (Some(Role::Viewer), GameEvent::UserInput(UserAction::Quit)) => true, // Local viewer quit
+    _ => false,
+};
+```
+
+### 5c. `net_tx` calls
+All `net_tx.send(GameMessage::...)` become `net_tx.send(OutboundMsg::Broadcast(GameMessage::...))` since game state updates go to all peers.
+
+### 5d. `PeerDisconnected` handling
+- `PeerDisconnected(pid)` where `pid == holder_peer_id`: end the round (holder left)
+- `PeerDisconnected(pid)` where `pid` is a viewer: continue playing (non-fatal)
+
+### 5e. `run_remote_game()` -- minimal changes
+- `RemoteInput` variant now carries PeerId but the joiner doesn't receive RemoteInput events (those come from the host's perspective). No change needed.
+- `PeerDisconnected` now carries PeerId; only react to PeerId 0 (host).
+- All other behavior is unchanged.
+
+---
+
+## Phase 6: Rendering (`crates/client/src/render.rs`)
+
+Add new render functions:
+- `render_host_lobby()` -- multi-player waiting room with participant list and Start/Settings/Disconnect
+- `render_holder_picker()` -- participant list as selectable items for holder selection
+- `render_post_game_multi()` -- post-game menu with "Play Again" / "Pick Next Holder" / "Quit"
+
+Existing render functions (`render_question`, `render_holder_view`, `render_role_assigned`, `render_joined_room`, `render_post_game_menu`, flash functions) need no changes -- each client renders locally based on their assigned role.
+
+---
+
+## Phase 7: Cleanup
+
+- Remove `SwapRoles` from `GameMessage` and all match arms
+- Remove "Spectator mode" line from `TODO.md`
+- Update `CLAUDE.md` architecture docs and `README.md`
+
+---
+
+## Implementation Order
+
+1. **Protocol crate** -- all type changes first (compile errors will guide client/relay updates)
+2. **Relay server** -- Room struct, join/create/handle refactors
+3. **Client types.rs** -- GameEvent updates
+4. **Client net.rs** -- OutboundMsg, read/write task updates
+5. **Client lobby.rs** -- wait_for_players, select_holder, session loops, post-game
+6. **Client game.rs** -- input routing, outbound changes, disconnect handling
+7. **Client render.rs** -- new lobby/picker/post-game screens
+8. **Cleanup** -- remove SwapRoles, update TODO/CLAUDE.md/README.md
+
+## Files Modified
+
+| File | Change Scope |
+|------|-------------|
+| `crates/protocol/src/lib.rs` | PeerId type, all message enum updates |
+| `crates/relay/src/main.rs` | Room struct, join/create, handle_host/joiner rewrite, remove run_forwarding |
+| `crates/client/src/types.rs` | GameEvent enum updates |
+| `crates/client/src/net.rs` | OutboundMsg enum, read/write task updates |
+| `crates/client/src/lobby.rs` | wait_for_players, select_holder, session loops, post-game menu |
+| `crates/client/src/game.rs` | run_game signature + input routing, run_remote_game PeerDisconnected |
+| `crates/client/src/render.rs` | New render functions for lobby/picker/post-game |
+| `TODO.md` | Remove spectator mode line |
+| `CLAUDE.md` | Update architecture docs |
+| `README.md` | Update feature description |
+
+## Files NOT Modified
+
+| File | Reason |
+|------|--------|
+| `crates/client/src/input.rs` | Produces UserInput events unchanged |
+| `crates/client/src/timer.rs` | Timer is host-local, unaffected |
+| `crates/client/src/config.rs` | Game settings still host-only |
+| `crates/client/src/menu.rs` | Menu structure unchanged (Solo/Host/Join/Settings/Quit); lobby changes are internal to lobby.rs |
+| `crates/client/src/main.rs` | run_host/run_join just call into lobby |
+
+## Verification
+
+1. `cargo build --release` -- all crates compile clean
+2. `cargo clippy` -- no warnings
+3. `cargo fmt --check` -- formatting clean
+4. **Solo mode regression**: solo play works exactly as before
+5. **2-player regression**: 1 host + 1 joiner works (special case of multi-viewer)
+6. **Multi-viewer**: 1 host + 3 joiners, host picks a joiner as Holder, play a round
+7. **Holder rotation**: after round, host picks a different Holder
+8. **Joiner disconnect**: viewer disconnects mid-game, game continues for remaining players
+9. **Holder disconnect**: holder joiner disconnects mid-game, round ends
+10. **Host disconnect**: all joiners see "Host disconnected" and exit
+11. **Room full**: 9th joiner gets `RoomFull` error
+12. **Late joiner**: joiner connects while host is in lobby, appears in participant list

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Rust build output
+/target/
+**/target/
+
+# Cargo
+Cargo.lock.bak
+**/*.rs.bk
+
+# Backup and temp files
+*.swp
+*.swo
+*~
+
+# OS metadata
+.DS_Store
+Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-An ASOIAF (A Song of Ice and Fire) themed "Guess Up" party game for the terminal, built in Rust. Players see a name/term on screen and press `y` (correct) or `n` (pass) before the timer runs out. Supports solo play and networked two-player mode via a relay server.
+An ASOIAF (A Song of Ice and Fire) themed "Guess Up" party game for the terminal, built in Rust. Players see a name/term on screen and press `y` (correct) or `n` (pass) before the timer runs out. Supports solo play and networked multi-player mode (1 host + up to 8 joiners) via a relay server.
 
 ## Build & Run
 
@@ -32,7 +32,7 @@ Cargo workspace with three crates:
 ```
 crates/
   protocol/   # shared message types (ClientMessage, RelayMessage, GameMessage) + TCP framing (length-prefixed JSON)
-  relay/      # standalone relay server binary — room management, message forwarding, heartbeat pings
+  relay/      # standalone relay server binary — room management (1 host + up to 8 peers), message forwarding (broadcast/targeted), heartbeat pings
   client/     # the game binary (solo + networked modes)
 ```
 
@@ -60,8 +60,8 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 | `input.rs` | `input_task()` — crossterm `EventStream`, single-keypress in raw mode |
 | `timer.rs` | `timer_task()` — 1s interval ticks, bonus-time channel for extra-time mode |
 | `render.rs` | `TerminalGuard` (RAII cleanup), `MenuItem` enum, menu rendering, game rendering, flash, countdown, lobby screens, summary output |
-| `net.rs` | `NetConnection` (TCP connect/split/reassemble), `NetHandle` (spawn read/write tasks, recoverable shutdown) |
-| `lobby.rs` | Room creation, host lobby (wait for peer with settings), role selection (with settings), joiner session loop, post-game menu, connection recovery across games |
+| `net.rs` | `NetConnection` (TCP connect/split/reassemble), `NetHandle` (spawn read/write tasks, recoverable shutdown), `OutboundMsg` (Broadcast/SendTo routing) |
+| `lobby.rs` | Room creation, host lobby (wait for players with live participant list), holder selection (pick any participant), joiner session loop, post-game menu (play again / pick next holder / quit), connection recovery across games |
 
 The key invariant is that `input.rs` stays separate from `game.rs` to allow swapping input sources.
 
@@ -71,8 +71,9 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 - **Flash race condition**: `flash_screen()` clobbers the display; after 150ms it sends `GameEvent::Redraw` so the game loop re-renders the current word. Both game loops track a `flashing` flag to skip renders while the flash is on screen, preventing the game loop or timer ticks from overwriting the flash effect.
 - **Summary rendering**: `TerminalGuard` must be dropped *before* `print_output()` — otherwise the summary prints inside the alternate screen buffer and gets wiped.
 - **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting. Both host and joiner recover connections after each game for multi-round play.
-- **Host-authoritative model**: The host owns all game state (words, timer, score). The joiner runs `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput`, Holder processes `UserInput`.
-- **Joiner post-game**: After a game, the joiner waits for the host's next `RoleAssignment` (signaling a new round) rather than intermediate `PlayAgain`/`SwapRoles` messages. This avoids a race condition where the net read task could consume messages during shutdown.
+- **Host-authoritative model**: The host owns all game state (words, timer, score). Joiners run `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput` from the holder's `PeerId`, Holder processes `UserInput`. The host picks who the Holder is from a participant list (can be themselves or any joiner).
+- **Multi-viewer rooms**: Rooms support 1 host + up to 8 joiners. The relay server manages a `Vec<Peer>` per room, assigns monotonically increasing PeerIds, and routes messages (broadcast or targeted). Only host disconnect removes the room; joiner disconnect is non-fatal.
+- **Joiner post-game**: After a game, the joiner waits for the host's next `RoleAssignment` (signaling a new round) rather than intermediate `PlayAgain`/`PickNextHolder` messages. This avoids a race condition where the net read task could consume messages during shutdown.
 - **Menu-driven game dispatch**: `menu_loop` owns the full lifecycle — it runs games internally and loops back to the appropriate screen (server connect, room code) after each game ends, preserving menu state.
 - **Settings persistence**: `AppConfig` is loaded from `~/.guess_up_config.json` on startup and saved after each menu exit or game. `#[serde(default)]` ensures forward compatibility.
 - **Address validation**: Relay server addresses are validated (host:port format, numeric port 1-65535) before connection attempts. Errors display inline in red on the input screen.
@@ -81,10 +82,10 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 
 ### Protocol
 
-The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`/`write_frame`, max 64KB). Three message layers:
-- **ClientMessage**: client → relay (CreateRoom, JoinRoom, GameData, Disconnect, Pong)
-- **RelayMessage**: relay → client (RoomCreated, PeerJoined, GameData, PeerDisconnected, Ping)
-- **GameMessage**: peer ↔ peer (forwarded through relay) — role assignment, word updates, timer sync, score, input, post-game actions
+The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`/`write_frame`, max 64KB). Peers are identified by `PeerId` (u8); host is always `HOST_PEER_ID` (0), joiners get 1, 2, 3, etc. assigned by the relay. Three message layers:
+- **ClientMessage**: client → relay (CreateRoom, JoinRoom, GameData { msg, target }, Disconnect, Pong). `target: None` broadcasts, `target: Some(id)` sends to a specific peer.
+- **RelayMessage**: relay → client (RoomCreated, PeerJoined { peer_id }, JoinedRoom { peer_id }, PeerList { peers }, GameData { msg, from }, PeerDisconnected { peer_id }, Ping)
+- **GameMessage**: peer ↔ peer (forwarded through relay) — RoleAssignment { holder_id }, word updates, timer sync, score, input, post-game actions (PlayAgain, PickNextHolder, QuitSession)
 
 ## Testing
 
@@ -94,10 +95,14 @@ Manual play-testing is the primary test strategy. Key scenarios to verify:
 2. Settings → change game_time → exit → re-run → value persisted in `~/.guess_up_config.json`
 3. Solo → plays full game → returns to main menu
 4. Category picker → scroll through categories → select one → only those words appear
-5. Host → server connect screen → type address → connect → room created → settings accessible while waiting
+5. Host → server connect screen → type address → connect → room created → lobby shows player list → settings accessible while waiting
 6. Join → server connect → enter room code → wrong code shows error inline → correct code joins
-7. Networked: host + join, role selection, play-again/swap-roles flow, peer disconnect handling
-8. Room stays alive across games — PlayAgain and SwapRoles work without reconnecting
+7. Networked: host + joiners, holder selection from participant list, play-again/pick-next-holder flow, peer disconnect handling
+8. Room stays alive across games — PlayAgain and PickNextHolder work without reconnecting
+9. Multi-viewer: 1 host + multiple joiners, host picks a joiner as Holder, all viewers see words
+10. Holder rotation: after round, host picks a different Holder via "Pick Next Holder"
+11. Joiner disconnect mid-game: viewer leaves, game continues; holder leaves, round ends
+12. Room full: 9th joiner gets RoomFull error
 9. Ctrl+C during game — terminal restores cleanly
 10. `~/.guess_up_history.json` is written after a game
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guess Up! - ASOIAF Edition
 
-A terminal-based "Guess Up" party game themed around A Song of Ice and Fire. Play solo (hold the screen to your forehead while friends give clues) or networked (two players on different machines connected through a relay server).
+A terminal-based "Guess Up" party game themed around A Song of Ice and Fire. Play solo (hold the screen to your forehead while friends give clues) or networked with up to 9 players (1 host + 8 joiners) connected through a relay server.
 
 Press `y` for correct, `n` to pass — no Enter needed.
 
@@ -26,16 +26,16 @@ Select **Solo Game** from the main menu. Adjust settings (game time, category, e
 
 ## Networked Mode
 
-Two players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and the other **joins** with a room code.
+Up to 9 players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and up to 8 others **join** with a room code.
 
 ### Hosting a Game
 
-Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code and lets you adjust **Settings** while waiting for an opponent. Once a joiner connects, pick your role:
+Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code, a live participant list, and lets you adjust **Settings** while waiting for players. Once at least one joiner connects, press **Start Game** and pick who will be the **Holder**:
 
-- **Viewer** — sees the word on screen and gives verbal clues
-- **Holder** — guesses based on clues and presses `y`/`n`
+- **Holder** — guesses based on clues and presses `y`/`n` (can be the host or any joiner)
+- **Viewer** — everyone else sees the word on screen and gives verbal clues
 
-After each game, the host gets a post-game menu to play again, swap roles, or quit. The room stays alive across games — no need to reconnect.
+After each game, the host gets a post-game menu to play again (same holder), pick a new holder, or quit. The room stays alive across games — no need to reconnect.
 
 ### Joining a Game
 
@@ -43,7 +43,7 @@ Select **Join Game** from the main menu, enter the relay server address, then ty
 
 ### Relay Server Setup
 
-The relay is a lightweight TCP server that forwards messages between the two players. It knows nothing about game logic — all state lives on the host client.
+The relay is a lightweight TCP server that forwards messages between players. It knows nothing about game logic — all state lives on the host client. Rooms support up to 8 joiners plus the host.
 
 **Build and deploy:**
 
@@ -157,9 +157,9 @@ Lines are trimmed and deduplicated automatically.
 - **End-of-round summary** — score, accuracy %, pace, and missed words
 - **Game history** — results saved to `~/.guess_up_history.json`
 - **Category filtering** — scrollable picker with all 25 categories
-- **Networked play** — two players on different machines via relay server
-- **Role selection** — host picks Viewer or Holder, swap after each game
-- **Post-game menu** — play again, swap roles, or quit (room stays alive)
+- **Multi-player rooms** — 1 host + up to 8 joiners via relay server
+- **Holder selection** — host picks who holds the device from a participant list
+- **Post-game menu** — play again, pick next holder, or quit (room stays alive)
 - **Address validation** — relay addresses validated before connecting
 - **Recent servers** — last 10 relay addresses remembered
 
@@ -194,8 +194,8 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 | `input.rs` | Async single-keypress input via crossterm |
 | `timer.rs` | 1-second interval ticks, bonus-time support |
 | `render.rs` | Terminal guard (RAII cleanup), all rendering (game + lobby) |
-| `net.rs` | TCP connection to relay, message translation |
-| `lobby.rs` | Room setup, role selection, post-game flow |
+| `net.rs` | TCP connection to relay, message translation, broadcast/targeted routing |
+| `lobby.rs` | Room setup, multi-player lobby, holder selection, post-game flow |
 
 ## Roadmap
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,10 +22,10 @@
 
 ## Hard
 
-- [ ] Multi-viewer support — one host, up to 8 viewers in the same room
+- [x] Multi-viewer support — one host, up to 8 viewers in the same room ([plan](.claude/multi-viewer-plan.md))
 - [ ] Server-side persistent stats — track date, games, scores, average, game type, slowest/fastest guess per session. Add player name system so matchup history (who played whom) is recorded. Historical trends viewable from client
 - [ ] Dynamic word difficulty — calculate difficulty from historical data (guess time + skip rate relative to other words). Display word color based on difficulty. No filtering, just informational
-- [ ] Spectator mode — read-only viewers who can watch a networked game in progress
+- [ ] ~~Spectator mode~~ — superseded by multi-viewer support
 
 ## Completed
 

--- a/crates/client/src/game.rs
+++ b/crates/client/src/game.rs
@@ -1,7 +1,8 @@
+use crate::net::OutboundMsg;
 use crate::render;
 use crate::types::*;
 use chrono::Local;
-use protocol::{FlashKind, GameMessage, NetGameResult, Role};
+use protocol::{FlashKind, GameMessage, NetGameResult, PeerId, Role};
 use rand::seq::SliceRandom;
 use std::fs;
 use tokio::sync::mpsc;
@@ -51,20 +52,24 @@ impl GameState {
 
 /// Run the host (authoritative) game loop.
 ///
-/// - `net_tx`: if Some, send GameMessages to the remote peer
+/// - `net_tx`: if Some, send OutboundMsgs to remote peers
 /// - `local_role`: if Some, we're in networked mode. None = solo.
+/// - `holder_peer_id`: identifies which remote peer is the Holder.
+///   None if host is Holder or solo mode.
 ///
 /// In networked mode, input routing depends on role:
-/// - Viewer (local) → holder is remote → process `RemoteInput`
+/// - Viewer (local) → holder is remote → process `RemoteInput` from holder
 /// - Holder (local) → holder is local → process `UserInput`
+#[allow(clippy::too_many_arguments)]
 pub async fn run_game(
     config: GameConfig,
     words: Vec<String>,
     mut rx: EventReceiver,
     bonus_tx: Option<BonusSender>,
     flash_tx: EventSender,
-    net_tx: Option<mpsc::Sender<GameMessage>>,
+    net_tx: Option<mpsc::Sender<OutboundMsg>>,
     local_role: Option<Role>,
+    holder_peer_id: Option<PeerId>,
 ) -> GameSummary {
     let term_size = render::terminal_size();
     let mut state = GameState::new(words, config.game_time, term_size);
@@ -88,28 +93,32 @@ pub async fn run_game(
     // Send initial word to remote if networked
     if let Some(ref tx) = net_tx {
         let _ = tx
-            .send(GameMessage::WordUpdate {
+            .send(OutboundMsg::Broadcast(GameMessage::WordUpdate {
                 word: first_word.to_string(),
-            })
+            }))
             .await;
         let _ = tx
-            .send(GameMessage::TimerSync {
+            .send(OutboundMsg::Broadcast(GameMessage::TimerSync {
                 seconds_left: state.seconds_left,
-            })
+            }))
             .await;
     }
 
     while let Some(event) = rx.recv().await {
         match event {
             // Route input based on role
-            GameEvent::UserInput(action) | GameEvent::RemoteInput(action) => {
+            GameEvent::UserInput(action) | GameEvent::RemoteInput(_, action) => {
                 // Determine if this input should be processed
                 let should_process = match (local_role, &event) {
                     // Solo mode: process all UserInput
                     (None, GameEvent::UserInput(_)) => true,
-                    // Networked, local is Viewer: holder is remote, process RemoteInput
-                    (Some(Role::Viewer), GameEvent::RemoteInput(_)) => true,
-                    // Networked, local is Holder: holder is local, process UserInput
+                    // Networked, host is Viewer: holder is remote, process RemoteInput from holder
+                    (Some(Role::Viewer), GameEvent::RemoteInput(pid, _))
+                        if Some(*pid) == holder_peer_id =>
+                    {
+                        true
+                    }
+                    // Networked, host is Holder: process local UserInput
                     (Some(Role::Holder), GameEvent::UserInput(_)) => true,
                     // Networked, local is Viewer: forward local quit but ignore y/n
                     (Some(Role::Viewer), GameEvent::UserInput(UserAction::Quit)) => true,
@@ -131,7 +140,11 @@ pub async fn run_game(
                         flashing = true;
                         render::flash_correct(flash_tx.clone());
                         if let Some(ref tx) = net_tx {
-                            let _ = tx.send(GameMessage::Flash(FlashKind::Correct)).await;
+                            let _ = tx
+                                .send(OutboundMsg::Broadcast(GameMessage::Flash(
+                                    FlashKind::Correct,
+                                )))
+                                .await;
                         }
                         if let (Some(ref tx), GameMode::ExtraTime { bonus_seconds }) =
                             (&bonus_tx, &config.mode)
@@ -144,7 +157,11 @@ pub async fn run_game(
                         flashing = true;
                         render::flash_incorrect(flash_tx.clone());
                         if let Some(ref tx) = net_tx {
-                            let _ = tx.send(GameMessage::Flash(FlashKind::Incorrect)).await;
+                            let _ = tx
+                                .send(OutboundMsg::Broadcast(GameMessage::Flash(
+                                    FlashKind::Incorrect,
+                                )))
+                                .await;
                         }
                     }
                     UserAction::Quit => break,
@@ -155,10 +172,10 @@ pub async fn run_game(
                 // Send score update to remote
                 if let Some(ref tx) = net_tx {
                     let _ = tx
-                        .send(GameMessage::ScoreUpdate {
+                        .send(OutboundMsg::Broadcast(GameMessage::ScoreUpdate {
                             score: state.score,
                             total: state.total_questions,
-                        })
+                        }))
                         .await;
                 }
 
@@ -169,9 +186,9 @@ pub async fn run_game(
                         }
                         if let Some(ref tx) = net_tx {
                             let _ = tx
-                                .send(GameMessage::WordUpdate {
+                                .send(OutboundMsg::Broadcast(GameMessage::WordUpdate {
                                     word: word.to_string(),
-                                })
+                                }))
                                 .await;
                         }
                     }
@@ -190,16 +207,18 @@ pub async fn run_game(
                 }
                 if let Some(ref tx) = net_tx {
                     let _ = tx
-                        .send(GameMessage::TimerSync {
+                        .send(OutboundMsg::Broadcast(GameMessage::TimerSync {
                             seconds_left: remaining,
-                        })
+                        }))
                         .await;
                 }
             }
             GameEvent::TimerExpired => {
                 render::bell();
                 if let Some(ref tx) = net_tx {
-                    let _ = tx.send(GameMessage::TimerExpired).await;
+                    let _ = tx
+                        .send(OutboundMsg::Broadcast(GameMessage::TimerExpired))
+                        .await;
                 }
                 if config.last_unlimited {
                     if let Some(word) = state.current_word() {
@@ -207,7 +226,11 @@ pub async fn run_game(
                         while let Some(evt) = rx.recv().await {
                             let action = match (&evt, local_role) {
                                 (GameEvent::UserInput(a), None | Some(Role::Holder)) => Some(*a),
-                                (GameEvent::RemoteInput(a), Some(Role::Viewer)) => Some(*a),
+                                (GameEvent::RemoteInput(pid, a), Some(Role::Viewer))
+                                    if Some(*pid) == holder_peer_id =>
+                                {
+                                    Some(*a)
+                                }
                                 _ => None,
                             };
                             if let Some(action) = action {
@@ -236,10 +259,19 @@ pub async fn run_game(
                     render_for_role(word, &state, local_role);
                 }
             }
-            GameEvent::PeerDisconnected => {
-                render::render_message("Opponent disconnected", state.term_size);
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                break;
+            GameEvent::PeerDisconnected(pid) => {
+                if Some(pid) == holder_peer_id {
+                    // Holder disconnected — end the round
+                    render::render_message("Holder disconnected", state.term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    break;
+                } else if local_role.is_some() && pid == 0 {
+                    // Host disconnected (shouldn't happen in host game, but handle it)
+                    render::render_message("Host disconnected", state.term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    break;
+                }
+                // Viewer disconnected — non-fatal, continue playing
             }
             _ => {} // Ignore Net* events in host game loop (they're for remote render)
         }
@@ -250,13 +282,15 @@ pub async fn run_game(
     // Send game over to remote
     if let Some(ref tx) = net_tx {
         let _ = tx
-            .send(GameMessage::GameOver(NetGameResult {
-                score: state.score,
-                total_questions: state.total_questions,
-                missed_words: state.missed_words.clone(),
-                game_time: config.game_time,
-                all_used,
-            }))
+            .send(OutboundMsg::Broadcast(GameMessage::GameOver(
+                NetGameResult {
+                    score: state.score,
+                    total_questions: state.total_questions,
+                    missed_words: state.missed_words.clone(),
+                    game_time: config.game_time,
+                    all_used,
+                },
+            )))
             .await;
     }
 
@@ -288,7 +322,7 @@ fn render_for_role(word: &str, state: &GameState, local_role: Option<Role>) {
 pub async fn run_remote_game(
     role: Role,
     mut rx: EventReceiver,
-    net_tx: mpsc::Sender<GameMessage>,
+    net_tx: mpsc::Sender<OutboundMsg>,
     flash_tx: EventSender,
 ) -> GameSummary {
     let term_size = render::terminal_size();
@@ -357,21 +391,28 @@ pub async fn run_remote_game(
                 // If we're the holder, forward input to host
                 if role == Role::Holder {
                     let net_action: protocol::NetUserAction = action.into();
-                    let _ = net_tx.send(GameMessage::PlayerInput(net_action)).await;
+                    let _ = net_tx
+                        .send(OutboundMsg::Broadcast(GameMessage::PlayerInput(net_action)))
+                        .await;
                     if action == UserAction::Quit {
                         break;
                     }
                 } else if action == UserAction::Quit {
                     let _ = net_tx
-                        .send(GameMessage::PlayerInput(protocol::NetUserAction::Quit))
+                        .send(OutboundMsg::Broadcast(GameMessage::PlayerInput(
+                            protocol::NetUserAction::Quit,
+                        )))
                         .await;
                     break;
                 }
             }
-            GameEvent::PeerDisconnected => {
-                render::render_message("Opponent disconnected", term_size);
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                break;
+            GameEvent::PeerDisconnected(pid) => {
+                if pid == protocol::HOST_PEER_ID {
+                    render::render_message("Host disconnected", term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    break;
+                }
+                // Other peer disconnects: ignore (host handles it)
             }
             GameEvent::Redraw => {
                 flashing = false;

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -8,7 +8,9 @@ use crate::timer;
 use crate::types::*;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures::StreamExt;
-use protocol::{ClientMessage, GameMessage, NetGameConfig, RelayMessage, Role};
+use protocol::{
+    ClientMessage, GameMessage, NetGameConfig, PeerId, RelayMessage, Role, HOST_PEER_ID,
+};
 use std::io::{self, ErrorKind};
 
 // ─── Host session ────────────────────────────────────────────────────
@@ -35,15 +37,17 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
 
     let mut guard = Some(render::TerminalGuard::new());
 
-    // Wait for peer (with settings access)
-    let wait_result = wait_for_peer(&code, &mut conn, app_config).await?;
-    if !wait_result {
-        let _ = conn.send_client_msg(&ClientMessage::Disconnect).await;
-        return Ok(());
-    }
+    // Wait for players (multi-viewer lobby)
+    let mut peers = match wait_for_players(&code, &mut conn, app_config).await? {
+        Some(peers) => peers,
+        None => {
+            let _ = conn.send_client_msg(&ClientMessage::Disconnect).await;
+            return Ok(());
+        }
+    };
 
-    // Role selection
-    let mut host_role = select_role(app_config).await;
+    // Holder selection
+    let mut holder_id = select_holder(&peers, app_config).await;
 
     loop {
         // Rebuild config and words from current settings each round
@@ -64,23 +68,64 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
 
         let term_size = render::terminal_size();
 
-        // Send role assignment to joiner
-        conn.send_client_msg(&ClientMessage::GameData(GameMessage::RoleAssignment {
-            host_role,
-        }))
+        // Send role assignment to all joiners (broadcast)
+        conn.send_client_msg(&ClientMessage::GameData {
+            msg: GameMessage::RoleAssignment { holder_id },
+            target: None,
+        })
         .await?;
 
-        // Wait for role accepted
+        // Wait for role accepted from all joiners
+        let mut accepted = std::collections::HashSet::new();
         loop {
+            if accepted.len() >= peers.len() {
+                break;
+            }
             match conn.recv_relay_msg().await? {
-                Some(RelayMessage::GameData(GameMessage::RoleAccepted)) => break,
+                Some(RelayMessage::GameData {
+                    msg: GameMessage::RoleAccepted,
+                    from,
+                }) => {
+                    accepted.insert(from);
+                }
                 Some(RelayMessage::Ping) => {
                     conn.send_client_msg(&ClientMessage::Pong).await?;
                 }
-                Some(RelayMessage::PeerDisconnected) | None => {
-                    render::render_message("Opponent disconnected", term_size);
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    return Ok(());
+                Some(RelayMessage::PeerDisconnected { peer_id }) => {
+                    peers.retain(|&p| p != peer_id);
+                    accepted.remove(&peer_id);
+                    if peers.is_empty() {
+                        render::render_message("All players disconnected", term_size);
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                        return Ok(());
+                    }
+                    // If the holder disconnected, pick the host as holder
+                    if peer_id == holder_id {
+                        holder_id = HOST_PEER_ID;
+                        // Re-send role assignment
+                        conn.send_client_msg(&ClientMessage::GameData {
+                            msg: GameMessage::RoleAssignment { holder_id },
+                            target: None,
+                        })
+                        .await?;
+                        accepted.clear();
+                    }
+                }
+                Some(RelayMessage::PeerJoined { peer_id }) => {
+                    // Late joiner during role assignment — add them but
+                    // they'll need a role assignment too
+                    peers.push(peer_id);
+                    conn.send_client_msg(&ClientMessage::GameData {
+                        msg: GameMessage::RoleAssignment { holder_id },
+                        target: Some(peer_id),
+                    })
+                    .await?;
+                }
+                None => {
+                    return Err(io::Error::new(
+                        ErrorKind::ConnectionAborted,
+                        "Relay disconnected",
+                    ));
                 }
                 _ => {}
             }
@@ -97,8 +142,18 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
             },
             word_count: words.len(),
         };
-        conn.send_client_msg(&ClientMessage::GameData(GameMessage::GameStart(net_config)))
-            .await?;
+        conn.send_client_msg(&ClientMessage::GameData {
+            msg: GameMessage::GameStart(net_config),
+            target: None,
+        })
+        .await?;
+
+        // Determine host's local role
+        let host_role = if holder_id == HOST_PEER_ID {
+            Role::Holder
+        } else {
+            Role::Viewer
+        };
 
         render::render_role_assigned(host_role, term_size);
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -107,8 +162,16 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
             render::render_countdown(term_size);
         }
 
+        // holder_peer_id is Some(id) if a joiner is the holder, None if host is holder
+        let holder_peer = if holder_id == HOST_PEER_ID {
+            None
+        } else {
+            Some(holder_id)
+        };
+
         // --- Run the game ---
-        let (summary, recovered_conn) = run_host_game(&config, words, conn, host_role).await;
+        let (summary, recovered_conn) =
+            run_host_game(&config, words, conn, host_role, holder_peer).await;
 
         conn = match recovered_conn {
             Some(c) => c,
@@ -127,14 +190,11 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
         // Re-enter alternate screen for post-game menu
         guard = Some(render::TerminalGuard::new());
 
-        let post_action = run_post_game_menu(&mut conn).await?;
+        let post_action = run_post_game_menu(&mut conn, &mut peers).await?;
         match post_action {
             PostGameAction::PlayAgain => {}
-            PostGameAction::SwapRoles => {
-                host_role = match host_role {
-                    Role::Viewer => Role::Holder,
-                    Role::Holder => Role::Viewer,
-                };
+            PostGameAction::PickNextHolder => {
+                holder_id = select_holder(&peers, app_config).await;
             }
             PostGameAction::Quit => {
                 let _ = conn.send_client_msg(&ClientMessage::Disconnect).await;
@@ -144,30 +204,48 @@ pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> i
     }
 }
 
-// ─── Wait for peer (with settings menu) ─────────────────────────────
+// ─── Wait for players (multi-viewer lobby) ──────────────────────────
 
-/// Wait for a peer to join the room. Returns `true` if a peer joined,
-/// `false` if the host chose to disconnect.
-async fn wait_for_peer(
+/// Wait for players to join the room. Returns `Some(Vec<PeerId>)` when
+/// the host starts the game, or `None` if the host disconnects.
+async fn wait_for_players(
     room_code: &str,
     conn: &mut NetConnection,
     app_config: &mut AppConfig,
-) -> io::Result<bool> {
+) -> io::Result<Option<Vec<PeerId>>> {
     let mut reader = EventStream::new();
     let mut selected: usize = 0;
-    let count = 2; // Settings, Disconnect
+    let mut peers: Vec<PeerId> = Vec::new();
 
     loop {
+        let has_players = !peers.is_empty();
+        let count = if has_players { 3 } else { 2 }; // Start (if players), Settings, Disconnect
+
         let term_size = render::terminal_size();
         let code_line = format!("Room: {}", room_code);
-        let items = [
-            MenuItem::Label("WAITING FOR OPPONENT..."),
-            MenuItem::Label(""),
+        let player_count = format!("Players: {}/9", peers.len() + 1);
+
+        let mut items: Vec<MenuItem> = vec![
             MenuItem::Label(&code_line),
             MenuItem::Label(""),
-            MenuItem::Action("Settings"),
-            MenuItem::Action("Disconnect"),
+            MenuItem::Label(&player_count),
+            MenuItem::Label("  Host (you)"),
         ];
+        // Build player labels for each peer
+        let peer_labels: Vec<String> = peers
+            .iter()
+            .map(|pid| format!("  Player {}", pid))
+            .collect();
+        for label in &peer_labels {
+            items.push(MenuItem::Label(label));
+        }
+        items.push(MenuItem::Label(""));
+        if has_players {
+            items.push(MenuItem::Action("Start Game"));
+        }
+        items.push(MenuItem::Action("Settings"));
+        items.push(MenuItem::Action("Disconnect"));
+
         render::render_menu("HOST LOBBY", &items, selected, term_size);
 
         tokio::select! {
@@ -187,18 +265,43 @@ async fn wait_for_peer(
                     KeyCode::Down | KeyCode::Char('j') => {
                         selected = (selected + 1) % count;
                     }
-                    KeyCode::Enter => match selected {
-                        0 => menu::run_settings_inline(app_config, &mut reader).await,
-                        1 => return Ok(false),
-                        _ => {}
-                    },
-                    KeyCode::Esc | KeyCode::Char('q') => return Ok(false),
+                    KeyCode::Enter => {
+                        if has_players {
+                            match selected {
+                                0 => return Ok(Some(peers)),      // Start Game
+                                1 => menu::run_settings_inline(app_config, &mut reader).await,
+                                2 => return Ok(None),             // Disconnect
+                                _ => {}
+                            }
+                        } else {
+                            match selected {
+                                0 => menu::run_settings_inline(app_config, &mut reader).await,
+                                1 => return Ok(None),             // Disconnect
+                                _ => {}
+                            }
+                        }
+                    }
+                    KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
                     _ => {}
                 }
             }
             msg = conn.recv_relay_msg() => {
                 match msg? {
-                    Some(RelayMessage::PeerJoined) => return Ok(true),
+                    Some(RelayMessage::PeerJoined { peer_id }) => {
+                        peers.push(peer_id);
+                        // Reset selection to clamp it
+                        let new_count = if !peers.is_empty() { 3 } else { 2 };
+                        if selected >= new_count {
+                            selected = new_count - 1;
+                        }
+                    }
+                    Some(RelayMessage::PeerDisconnected { peer_id }) => {
+                        peers.retain(|&p| p != peer_id);
+                        let new_count = if !peers.is_empty() { 3 } else { 2 };
+                        if selected >= new_count {
+                            selected = new_count - 1;
+                        }
+                    }
                     Some(RelayMessage::Ping) => {
                         conn.send_client_msg(&ClientMessage::Pong).await?;
                     }
@@ -222,6 +325,7 @@ async fn run_host_game(
     words: Vec<String>,
     conn: NetConnection,
     local_role: Role,
+    holder_peer_id: Option<PeerId>,
 ) -> (game::GameSummary, Option<NetConnection>) {
     let (event_tx, event_rx) = tokio::sync::mpsc::channel::<GameEvent>(32);
     let (bonus_tx, bonus_rx) = tokio::sync::mpsc::channel::<u64>(16);
@@ -252,6 +356,7 @@ async fn run_host_game(
         flash_tx,
         Some(net_tx),
         Some(local_role),
+        holder_peer_id,
     )
     .await;
 
@@ -267,8 +372,8 @@ async fn run_host_game(
 // ─── Joiner session ─────────────────────────────────────────────────
 
 /// Connect to the relay and join a room. Returns the established connection
-/// on success, or an error (e.g. bad room code, connection refused).
-pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<NetConnection> {
+/// and the joiner's peer ID on success.
+pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<(NetConnection, PeerId)> {
     let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
         io::Error::new(
             ErrorKind::ConnectionRefused,
@@ -282,16 +387,28 @@ pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<NetConnec
     })
     .await?;
 
-    match conn.recv_relay_msg().await? {
-        Some(RelayMessage::JoinedRoom) => Ok(conn),
-        Some(RelayMessage::Error(e)) => Err(io::Error::other(format!("{}", e))),
-        _ => Err(io::Error::other("Unexpected relay response")),
+    let peer_id = match conn.recv_relay_msg().await? {
+        Some(RelayMessage::JoinedRoom { peer_id }) => peer_id,
+        Some(RelayMessage::Error(e)) => return Err(io::Error::other(format!("{}", e))),
+        _ => return Err(io::Error::other("Unexpected relay response")),
+    };
+
+    // Read and discard the PeerList — the joiner doesn't need it
+    // since the host manages the participant list
+    if let Some(RelayMessage::PeerList { .. }) = conn.recv_relay_msg().await? {
+        // Expected — consumed and discarded
     }
+
+    Ok((conn, peer_id))
 }
 
 /// Run the joiner game session on an already-joined connection.
 /// Loops across games until the host quits or disconnects.
-pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io::Result<()> {
+pub async fn run_joiner_session(
+    mut conn: NetConnection,
+    room_code: &str,
+    my_id: PeerId,
+) -> io::Result<()> {
     let mut guard = Some(render::TerminalGuard::new());
     let term_size = render::terminal_size();
     render::render_joined_room(room_code, term_size);
@@ -305,12 +422,12 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
 
         // Wait for role assignment from host. Between rounds the joiner
         // can press Q to quit. We also accept (and ignore) PlayAgain /
-        // SwapRoles messages — only RoleAssignment starts the next round.
+        // PickNextHolder messages — only RoleAssignment starts the next round.
         let my_role = {
             let msg = if waiting_for_next_round {
                 "Waiting for host..."
             } else {
-                "Waiting for host to choose roles..."
+                "Waiting for host to assign roles..."
             };
             let term_size = render::terminal_size();
             render::render_message(msg, term_size);
@@ -327,9 +444,10 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
                                 && matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc)
                             {
                                 let _ = conn
-                                    .send_client_msg(&ClientMessage::GameData(
-                                        GameMessage::QuitSession,
-                                    ))
+                                    .send_client_msg(&ClientMessage::GameData {
+                                        msg: GameMessage::QuitSession,
+                                        target: None,
+                                    })
                                     .await;
                                 return Ok(());
                             }
@@ -337,16 +455,19 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
                     }
                     msg = conn.recv_relay_msg() => {
                         match msg? {
-                            Some(RelayMessage::GameData(GameMessage::RoleAssignment {
-                                host_role,
-                            })) => {
-                                let role = match host_role {
-                                    Role::Viewer => Role::Holder,
-                                    Role::Holder => Role::Viewer,
+                            Some(RelayMessage::GameData {
+                                msg: GameMessage::RoleAssignment { holder_id },
+                                ..
+                            }) => {
+                                let role = if holder_id == my_id {
+                                    Role::Holder
+                                } else {
+                                    Role::Viewer
                                 };
-                                conn.send_client_msg(&ClientMessage::GameData(
-                                    GameMessage::RoleAccepted,
-                                ))
+                                conn.send_client_msg(&ClientMessage::GameData {
+                                    msg: GameMessage::RoleAccepted,
+                                    target: None,
+                                })
                                 .await?;
                                 let term_size = render::terminal_size();
                                 render::render_role_assigned(role, term_size);
@@ -355,16 +476,27 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
                             Some(RelayMessage::Ping) => {
                                 conn.send_client_msg(&ClientMessage::Pong).await?;
                             }
-                            Some(RelayMessage::PeerDisconnected) | None => {
+                            Some(RelayMessage::PeerDisconnected { peer_id })
+                                if peer_id == HOST_PEER_ID =>
+                            {
                                 let term_size = render::terminal_size();
                                 render::render_message("Host disconnected", term_size);
                                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                                 return Ok(());
                             }
-                            Some(RelayMessage::GameData(GameMessage::QuitSession)) => {
+                            None => {
+                                let term_size = render::terminal_size();
+                                render::render_message("Host disconnected", term_size);
+                                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                                 return Ok(());
                             }
-                            // Ignore PlayAgain/SwapRoles — we only care about RoleAssignment
+                            Some(RelayMessage::GameData {
+                                msg: GameMessage::QuitSession,
+                                ..
+                            }) => {
+                                return Ok(());
+                            }
+                            // Ignore PlayAgain/PickNextHolder/PeerJoined/PeerDisconnected (non-host)
                             _ => {}
                         }
                     }
@@ -375,11 +507,20 @@ pub async fn run_joiner_session(mut conn: NetConnection, room_code: &str) -> io:
         // Wait for game start
         loop {
             match conn.recv_relay_msg().await? {
-                Some(RelayMessage::GameData(GameMessage::GameStart(_cfg))) => break,
+                Some(RelayMessage::GameData {
+                    msg: GameMessage::GameStart(_cfg),
+                    ..
+                }) => break,
                 Some(RelayMessage::Ping) => {
                     conn.send_client_msg(&ClientMessage::Pong).await?;
                 }
-                Some(RelayMessage::PeerDisconnected) | None => {
+                Some(RelayMessage::PeerDisconnected { peer_id }) if peer_id == HOST_PEER_ID => {
+                    let term_size = render::terminal_size();
+                    render::render_message("Host disconnected", term_size);
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    return Ok(());
+                }
+                None => {
                     let term_size = render::terminal_size();
                     render::render_message("Host disconnected", term_size);
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -433,22 +574,29 @@ async fn run_joiner_game(
     (summary, recovered)
 }
 
-// ─── Role selection (host only) ──────────────────────────────────────
+// ─── Holder selection (host only) ───────────────────────────────────
 
-async fn select_role(app_config: &mut AppConfig) -> Role {
+async fn select_holder(peers: &[PeerId], app_config: &mut AppConfig) -> PeerId {
     let mut selected: usize = 0;
     let mut reader = EventStream::new();
-    let count = 3; // Viewer, Holder, Settings
+
+    // Build participant list: Host + all peers
+    let participant_count = 1 + peers.len(); // Host + peers
+    let total_selectable = participant_count + 1; // participants + Settings
 
     loop {
         let term_size = render::terminal_size();
-        let items = [
-            MenuItem::Action("Viewer — See words, give clues"),
-            MenuItem::Action("Holder — Guess and press Y/N"),
-            MenuItem::Label(""),
-            MenuItem::Action("Settings"),
-        ];
-        render::render_menu("CHOOSE YOUR ROLE", &items, selected, term_size);
+
+        let mut items: Vec<MenuItem> = Vec::new();
+        items.push(MenuItem::Action("Host (you)"));
+        let peer_labels: Vec<String> = peers.iter().map(|pid| format!("Player {}", pid)).collect();
+        for label in &peer_labels {
+            items.push(MenuItem::Action(label));
+        }
+        items.push(MenuItem::Label(""));
+        items.push(MenuItem::Action("Settings"));
+
+        render::render_menu("CHOOSE THE HOLDER", &items, selected, term_size);
 
         let Some(Ok(event)) = reader.next().await else {
             continue;
@@ -464,19 +612,21 @@ async fn select_role(app_config: &mut AppConfig) -> Role {
         }
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                selected = selected.checked_sub(1).unwrap_or(count - 1);
+                selected = selected.checked_sub(1).unwrap_or(total_selectable - 1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                selected = (selected + 1) % count;
+                selected = (selected + 1) % total_selectable;
             }
-            KeyCode::Enter => match selected {
-                0 => return Role::Viewer,
-                1 => return Role::Holder,
-                2 => menu::run_settings_inline(app_config, &mut reader).await,
-                _ => {}
-            },
-            KeyCode::Char('v') | KeyCode::Char('V') => return Role::Viewer,
-            KeyCode::Char('h') | KeyCode::Char('H') => return Role::Holder,
+            KeyCode::Enter => {
+                if selected == 0 {
+                    return HOST_PEER_ID; // Host is holder
+                } else if selected <= peers.len() {
+                    return peers[selected - 1]; // A joiner is holder
+                } else {
+                    // Settings
+                    menu::run_settings_inline(app_config, &mut reader).await;
+                }
+            }
             _ => {}
         }
     }
@@ -486,11 +636,14 @@ async fn select_role(app_config: &mut AppConfig) -> Role {
 
 enum PostGameAction {
     PlayAgain,
-    SwapRoles,
+    PickNextHolder,
     Quit,
 }
 
-async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameAction> {
+async fn run_post_game_menu(
+    conn: &mut NetConnection,
+    peers: &mut Vec<PeerId>,
+) -> io::Result<PostGameAction> {
     let term_size = render::terminal_size();
     render::render_post_game_menu(term_size);
 
@@ -507,15 +660,24 @@ async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameActi
                     }
                     match key.code {
                         KeyCode::Char('p') | KeyCode::Char('P') => {
-                            conn.send_client_msg(&ClientMessage::GameData(GameMessage::PlayAgain)).await?;
+                            conn.send_client_msg(&ClientMessage::GameData {
+                                msg: GameMessage::PlayAgain,
+                                target: None,
+                            }).await?;
                             return Ok(PostGameAction::PlayAgain);
                         }
-                        KeyCode::Char('s') | KeyCode::Char('S') => {
-                            conn.send_client_msg(&ClientMessage::GameData(GameMessage::SwapRoles)).await?;
-                            return Ok(PostGameAction::SwapRoles);
+                        KeyCode::Char('n') | KeyCode::Char('N') => {
+                            conn.send_client_msg(&ClientMessage::GameData {
+                                msg: GameMessage::PickNextHolder,
+                                target: None,
+                            }).await?;
+                            return Ok(PostGameAction::PickNextHolder);
                         }
                         KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
-                            conn.send_client_msg(&ClientMessage::GameData(GameMessage::QuitSession)).await?;
+                            conn.send_client_msg(&ClientMessage::GameData {
+                                msg: GameMessage::QuitSession,
+                                target: None,
+                            }).await?;
                             return Ok(PostGameAction::Quit);
                         }
                         _ => {}
@@ -524,15 +686,14 @@ async fn run_post_game_menu(conn: &mut NetConnection) -> io::Result<PostGameActi
             }
             msg = conn.recv_relay_msg() => {
                 match msg? {
-                    Some(RelayMessage::GameData(GameMessage::QuitSession)) |
-                    Some(RelayMessage::PeerDisconnected) | None => {
+                    Some(RelayMessage::GameData { msg: GameMessage::QuitSession, .. }) => {
                         return Ok(PostGameAction::Quit);
                     }
-                    Some(RelayMessage::GameData(GameMessage::PlayAgain)) => {
-                        return Ok(PostGameAction::PlayAgain);
-                    }
-                    Some(RelayMessage::GameData(GameMessage::SwapRoles)) => {
-                        return Ok(PostGameAction::SwapRoles);
+                    Some(RelayMessage::PeerDisconnected { peer_id }) => {
+                        peers.retain(|&p| p != peer_id);
+                        if peers.is_empty() {
+                            return Ok(PostGameAction::Quit);
+                        }
                     }
                     Some(RelayMessage::Ping) => {
                         conn.send_client_msg(&ClientMessage::Pong).await?;

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -115,7 +115,17 @@ pub async fn run_solo(app_config: &AppConfig) {
     let timer_handle = tokio::spawn(timer::timer_task(timer_tx, app_config.game_time, bonus_rx));
 
     // Run game loop (blocks until game ends)
-    let summary = game::run_game(config, words, event_rx, bonus_sender, flash_tx, None, None).await;
+    let summary = game::run_game(
+        config,
+        words,
+        event_rx,
+        bonus_sender,
+        flash_tx,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     // Abort background tasks
     input_handle.abort();
@@ -139,8 +149,8 @@ pub async fn run_host(app_config: &mut AppConfig, relay_addr: &str) {
     }
 }
 
-pub async fn run_join(conn: NetConnection, room_code: &str) {
-    if let Err(e) = lobby::run_joiner_session(conn, room_code).await {
+pub async fn run_join(conn: NetConnection, room_code: &str, my_id: u8) {
+    if let Err(e) = lobby::run_joiner_session(conn, room_code, my_id).await {
         show_error(&format!("{}", e)).await;
     }
 }

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::render::{self, MenuItem};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures::StreamExt;
+use protocol::PeerId;
 
 enum Screen {
     Main,
@@ -148,10 +149,14 @@ async fn run_join_flow(
                 loop {
                     let join_result = run_join_room(&addr, reader).await;
                     match join_result {
-                        JoinRoomResult::Joined { conn, room_code } => {
+                        JoinRoomResult::Joined {
+                            conn,
+                            room_code,
+                            peer_id,
+                        } => {
                             // Drop guard before game
                             guard.take();
-                            crate::run_join(conn, &room_code).await;
+                            crate::run_join(conn, &room_code, peer_id).await;
                             // Restore guard and reader
                             *guard = Some(render::TerminalGuard::new());
                             *reader = EventStream::new();
@@ -581,6 +586,7 @@ enum JoinRoomResult {
     Joined {
         conn: crate::net::NetConnection,
         room_code: String,
+        peer_id: PeerId,
     },
     Back,
 }
@@ -630,10 +636,11 @@ async fn run_join_room(relay_addr: &str, reader: &mut EventStream) -> JoinRoomRe
                         render::render_message(&connecting_msg, term_size);
 
                         match crate::lobby::try_join_room(relay_addr, &code).await {
-                            Ok(conn) => {
+                            Ok((conn, peer_id)) => {
                                 return JoinRoomResult::Joined {
                                     conn,
                                     room_code: code,
+                                    peer_id,
                                 };
                             }
                             Err(e) => {

--- a/crates/client/src/net.rs
+++ b/crates/client/src/net.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use protocol::{read_frame, write_frame, ClientMessage, GameMessage, RelayMessage};
+use protocol::{read_frame, write_frame, ClientMessage, GameMessage, PeerId, RelayMessage};
 use tokio::io::{BufReader, BufWriter};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
@@ -7,6 +7,14 @@ use tokio::sync::{mpsc, oneshot};
 
 pub type Reader = BufReader<OwnedReadHalf>;
 pub type Writer = BufWriter<OwnedWriteHalf>;
+
+/// Outbound message from the game loop to the net write task.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum OutboundMsg {
+    Broadcast(GameMessage),
+    SendTo(PeerId, GameMessage),
+}
 
 pub struct NetConnection {
     pub reader: Reader,
@@ -43,7 +51,7 @@ impl NetConnection {
 
 /// Result of spawning net tasks — includes handles and a way to get the connection back.
 pub struct NetHandle {
-    pub outbound_tx: mpsc::Sender<GameMessage>,
+    pub outbound_tx: mpsc::Sender<OutboundMsg>,
     read_handle: tokio::task::JoinHandle<Reader>,
     write_handle: tokio::task::JoinHandle<Writer>,
     stop_tx: oneshot::Sender<()>,
@@ -66,7 +74,7 @@ impl NetHandle {
 /// Spawn background tasks that bridge the TCP connection to game event channels.
 /// Returns a NetHandle that can be used to send messages and recover the connection.
 pub fn spawn_net_tasks(conn: NetConnection, event_tx: EventSender) -> NetHandle {
-    let (outbound_tx, outbound_rx) = mpsc::channel::<GameMessage>(32);
+    let (outbound_tx, outbound_rx) = mpsc::channel::<OutboundMsg>(32);
     let (stop_tx, stop_rx) = oneshot::channel::<()>();
 
     let (reader, writer) = conn.into_parts();
@@ -96,8 +104,18 @@ async fn net_read_task(
                 match result {
                     Ok(Some(msg)) => {
                         let event = match msg {
-                            RelayMessage::GameData(game_msg) => translate_game_message(game_msg),
-                            RelayMessage::PeerDisconnected => Some(GameEvent::PeerDisconnected),
+                            RelayMessage::GameData { msg: game_msg, from } => {
+                                translate_game_message(game_msg, from)
+                            }
+                            RelayMessage::PeerDisconnected { peer_id } => {
+                                Some(GameEvent::PeerDisconnected(peer_id))
+                            }
+                            RelayMessage::PeerJoined { peer_id } => {
+                                Some(GameEvent::PeerJoined(peer_id))
+                            }
+                            RelayMessage::PeerList { peers } => {
+                                Some(GameEvent::PeerList(peers))
+                            }
                             RelayMessage::Ping => None, // Pong handled at lobby level
                             _ => None,
                         };
@@ -108,11 +126,11 @@ async fn net_read_task(
                         }
                     }
                     Ok(None) => {
-                        let _ = event_tx.send(GameEvent::PeerDisconnected).await;
+                        let _ = event_tx.send(GameEvent::PeerDisconnected(0)).await;
                         break;
                     }
                     Err(_) => {
-                        let _ = event_tx.send(GameEvent::PeerDisconnected).await;
+                        let _ = event_tx.send(GameEvent::PeerDisconnected(0)).await;
                         break;
                     }
                 }
@@ -122,9 +140,9 @@ async fn net_read_task(
     reader
 }
 
-fn translate_game_message(msg: GameMessage) -> Option<GameEvent> {
+fn translate_game_message(msg: GameMessage, from: PeerId) -> Option<GameEvent> {
     match msg {
-        GameMessage::PlayerInput(action) => Some(GameEvent::RemoteInput(action.into())),
+        GameMessage::PlayerInput(action) => Some(GameEvent::RemoteInput(from, action.into())),
         GameMessage::WordUpdate { word } => Some(GameEvent::NetWordUpdate(word)),
         GameMessage::TimerSync { seconds_left } => Some(GameEvent::NetTimerSync(seconds_left)),
         GameMessage::ScoreUpdate { score, total } => {
@@ -137,14 +155,23 @@ fn translate_game_message(msg: GameMessage) -> Option<GameEvent> {
     }
 }
 
-/// Reads GameMessages from the outbound channel and writes them to the TCP stream.
+/// Reads OutboundMsgs from the channel and writes them to the TCP stream.
 /// Returns the writer when the channel closes so the connection can be reused.
 async fn net_write_task(
     mut writer: Writer,
-    mut outbound_rx: mpsc::Receiver<GameMessage>,
+    mut outbound_rx: mpsc::Receiver<OutboundMsg>,
 ) -> Writer {
     while let Some(msg) = outbound_rx.recv().await {
-        let client_msg = ClientMessage::GameData(msg);
+        let client_msg = match msg {
+            OutboundMsg::Broadcast(game_msg) => ClientMessage::GameData {
+                msg: game_msg,
+                target: None,
+            },
+            OutboundMsg::SendTo(peer_id, game_msg) => ClientMessage::GameData {
+                msg: game_msg,
+                target: Some(peer_id),
+            },
+        };
         if write_frame(&mut writer, &client_msg).await.is_err() {
             break;
         }

--- a/crates/client/src/render.rs
+++ b/crates/client/src/render.rs
@@ -577,8 +577,8 @@ pub fn render_post_game_menu(term_size: (u16, u16)) {
     let lines = [
         "WHAT NEXT?",
         "",
-        "[P] Play again",
-        "[S] Swap roles",
+        "[P] Play again (same holder)",
+        "[N] Pick next holder",
         "[Q] Quit session",
     ];
     render_centered_box(&lines, term_size, Blue);

--- a/crates/client/src/types.rs
+++ b/crates/client/src/types.rs
@@ -1,4 +1,4 @@
-use protocol::{FlashKind, NetGameResult, NetUserAction};
+use protocol::{FlashKind, NetGameResult, NetUserAction, PeerId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -10,15 +10,24 @@ pub enum GameEvent {
     TimerExpired,
     Redraw,
 
-    // Network events (received from remote peer)
-    RemoteInput(UserAction),
+    // Network events (received from remote peers)
+    RemoteInput(PeerId, UserAction),
     NetWordUpdate(String),
     NetTimerSync(u64),
-    NetScoreUpdate { score: usize, total: usize },
+    NetScoreUpdate {
+        score: usize,
+        total: usize,
+    },
     NetFlash(FlashKind),
     NetTimerExpired,
     NetGameOver(NetGameResult),
-    PeerDisconnected,
+    PeerDisconnected(PeerId),
+
+    // Multi-viewer lobby events (produced by net_read_task, consumed during game)
+    #[allow(dead_code)]
+    PeerJoined(PeerId),
+    #[allow(dead_code)]
+    PeerList(Vec<PeerId>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -4,6 +4,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 // ─── Constants ───────────────────────────────────────────────────────
 const MAX_FRAME_SIZE: u32 = 65_536; // 64KB
 
+// ─── Peer ID ─────────────────────────────────────────────────────────
+
+pub type PeerId = u8;
+pub const HOST_PEER_ID: PeerId = 0;
+
 // ─── Framing ─────────────────────────────────────────────────────────
 
 /// Write a length-prefixed JSON frame to an async writer.
@@ -50,8 +55,13 @@ pub async fn read_frame<T: DeserializeOwned, R: AsyncReadExt + Unpin>(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ClientMessage {
     CreateRoom,
-    JoinRoom { code: String },
-    GameData(GameMessage),
+    JoinRoom {
+        code: String,
+    },
+    GameData {
+        msg: GameMessage,
+        target: Option<PeerId>,
+    },
     Disconnect,
     Pong,
 }
@@ -61,10 +71,11 @@ pub enum ClientMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RelayMessage {
     RoomCreated { code: String },
-    PeerJoined,
-    JoinedRoom,
-    GameData(GameMessage),
-    PeerDisconnected,
+    PeerJoined { peer_id: PeerId },
+    JoinedRoom { peer_id: PeerId },
+    PeerList { peers: Vec<PeerId> },
+    GameData { msg: GameMessage, from: PeerId },
+    PeerDisconnected { peer_id: PeerId },
     Error(RelayError),
     Ping,
 }
@@ -93,7 +104,7 @@ impl std::fmt::Display for RelayError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GameMessage {
     // Lobby
-    RoleAssignment { host_role: Role },
+    RoleAssignment { holder_id: PeerId },
     RoleAccepted,
     GameStart(NetGameConfig),
 
@@ -110,7 +121,7 @@ pub enum GameMessage {
 
     // Post-game
     PlayAgain,
-    SwapRoles,
+    PickNextHolder,
     QuitSession,
 }
 

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
-use protocol::{read_frame, write_frame, ClientMessage, RelayError, RelayMessage};
+use protocol::{
+    read_frame, write_frame, ClientMessage, PeerId, RelayError, RelayMessage, HOST_PEER_ID,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -7,6 +9,8 @@ use tokio::io::{BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
+
+const MAX_PEERS_PER_ROOM: usize = 8;
 
 #[derive(Parser, Debug)]
 #[command(version, about = "Guess Up relay server")]
@@ -24,10 +28,49 @@ struct Args {
     room_timeout: u64,
 }
 
+struct Peer {
+    tx: mpsc::Sender<RelayMessage>,
+    peer_id: PeerId,
+}
+
 struct Room {
     host_tx: mpsc::Sender<RelayMessage>,
-    joiner_tx: Option<mpsc::Sender<RelayMessage>>,
+    peers: Vec<Peer>,
+    next_peer_id: PeerId,
     created_at: Instant,
+}
+
+impl Room {
+    /// Send a message to all peers, optionally excluding one.
+    async fn broadcast_to_peers(&self, msg: &RelayMessage, exclude: Option<PeerId>) {
+        for peer in &self.peers {
+            if exclude == Some(peer.peer_id) {
+                continue;
+            }
+            let _ = peer.tx.send(msg.clone()).await;
+        }
+    }
+
+    /// Send a message to a specific peer. Returns false if peer not found.
+    async fn send_to_peer(&self, peer_id: PeerId, msg: RelayMessage) -> bool {
+        for peer in &self.peers {
+            if peer.peer_id == peer_id {
+                let _ = peer.tx.send(msg).await;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Remove a peer from the room by ID.
+    fn remove_peer(&mut self, peer_id: PeerId) {
+        self.peers.retain(|p| p.peer_id != peer_id);
+    }
+
+    /// Get a list of all peer IDs currently in the room.
+    fn peer_ids(&self) -> Vec<PeerId> {
+        self.peers.iter().map(|p| p.peer_id).collect()
+    }
 }
 
 struct RelayServer {
@@ -51,7 +94,10 @@ impl RelayServer {
         (0..5).map(|_| rng.gen_range(b'A'..=b'Z') as char).collect()
     }
 
-    async fn create_room(&self, host_tx: mpsc::Sender<RelayMessage>) -> Result<String, RelayError> {
+    async fn create_room(
+        &self,
+        host_tx: mpsc::Sender<RelayMessage>,
+    ) -> Result<(String, Arc<Mutex<Room>>), RelayError> {
         let rooms = self.rooms.read().await;
         if rooms.len() >= self.max_rooms {
             return Err(RelayError::ServerFull);
@@ -67,39 +113,48 @@ impl RelayServer {
             }
         };
 
-        rooms.insert(
-            code.clone(),
-            Arc::new(Mutex::new(Room {
-                host_tx,
-                joiner_tx: None,
-                created_at: Instant::now(),
-            })),
-        );
+        let room = Arc::new(Mutex::new(Room {
+            host_tx,
+            peers: Vec::new(),
+            next_peer_id: 1,
+            created_at: Instant::now(),
+        }));
 
-        Ok(code)
+        rooms.insert(code.clone(), Arc::clone(&room));
+
+        Ok((code, room))
     }
 
     async fn join_room(
         &self,
         code: &str,
         joiner_tx: mpsc::Sender<RelayMessage>,
-    ) -> Result<Arc<Mutex<Room>>, RelayError> {
+    ) -> Result<(Arc<Mutex<Room>>, PeerId), RelayError> {
         let rooms = self.rooms.read().await;
         let room = rooms.get(code).ok_or(RelayError::RoomNotFound)?;
         let room = Arc::clone(room);
         drop(rooms);
 
         let mut room_guard = room.lock().await;
-        if room_guard.joiner_tx.is_some() {
+        if room_guard.peers.len() >= MAX_PEERS_PER_ROOM {
             return Err(RelayError::RoomFull);
         }
-        room_guard.joiner_tx = Some(joiner_tx);
 
-        // Notify host
-        let _ = room_guard.host_tx.send(RelayMessage::PeerJoined).await;
+        let peer_id = room_guard.next_peer_id;
+        room_guard.next_peer_id = room_guard.next_peer_id.wrapping_add(1);
+
+        // Notify host and all existing peers
+        let join_msg = RelayMessage::PeerJoined { peer_id };
+        let _ = room_guard.host_tx.send(join_msg.clone()).await;
+        room_guard.broadcast_to_peers(&join_msg, None).await;
+
+        room_guard.peers.push(Peer {
+            tx: joiner_tx,
+            peer_id,
+        });
 
         drop(room_guard);
-        Ok(room)
+        Ok((room, peer_id))
     }
 
     async fn remove_room(&self, code: &str) {
@@ -188,8 +243,8 @@ async fn handle_host(
 ) -> std::io::Result<()> {
     let (tx, mut rx) = mpsc::channel::<RelayMessage>(32);
 
-    let code = match server.create_room(tx).await {
-        Ok(code) => code,
+    let (code, room) = match server.create_room(tx).await {
+        Ok(result) => result,
         Err(e) => {
             write_frame(&mut writer, &RelayMessage::Error(e)).await?;
             return Ok(());
@@ -203,9 +258,8 @@ async fn handle_host(
     )
     .await?;
 
-    // Wait for peer joined or host messages
-    // First, wait until a joiner connects by forwarding messages from the relay channel
-    let joiner_tx: mpsc::Sender<RelayMessage>;
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+    ping_interval.tick().await; // skip first immediate tick
 
     loop {
         tokio::select! {
@@ -213,47 +267,47 @@ async fn handle_host(
                 match msg {
                     Some(relay_msg) => {
                         write_frame(&mut writer, &relay_msg).await?;
-                        if matches!(relay_msg, RelayMessage::PeerJoined) {
-                            // Get joiner_tx from the room
-                            let rooms = server.rooms.read().await;
-                            let room = rooms.get(&code).unwrap();
-                            let room_guard = room.lock().await;
-                            joiner_tx = room_guard.joiner_tx.clone().unwrap();
-                            drop(room_guard);
-                            drop(rooms);
-                            break;
-                        }
                     }
-                    None => {
-                        server.remove_room(&code).await;
-                        return Ok(());
-                    }
+                    None => break,
                 }
             }
             msg = read_frame::<ClientMessage, _>(&mut reader) => {
                 match msg? {
+                    Some(ClientMessage::GameData { msg: game_msg, target: None }) => {
+                        // Broadcast to all peers
+                        let relay_msg = RelayMessage::GameData { msg: game_msg, from: HOST_PEER_ID };
+                        let room_guard = room.lock().await;
+                        room_guard.broadcast_to_peers(&relay_msg, None).await;
+                    }
+                    Some(ClientMessage::GameData { msg: game_msg, target: Some(id) }) => {
+                        // Send to specific peer
+                        let relay_msg = RelayMessage::GameData { msg: game_msg, from: HOST_PEER_ID };
+                        let room_guard = room.lock().await;
+                        room_guard.send_to_peer(id, relay_msg).await;
+                    }
                     Some(ClientMessage::Disconnect) | None => {
-                        server.remove_room(&code).await;
-                        return Ok(());
+                        // Notify all peers that host disconnected
+                        let room_guard = room.lock().await;
+                        let disconnect_msg = RelayMessage::PeerDisconnected { peer_id: HOST_PEER_ID };
+                        room_guard.broadcast_to_peers(&disconnect_msg, None).await;
+                        drop(room_guard);
+                        break;
                     }
                     Some(ClientMessage::Pong) => {}
-                    Some(_) => {} // Ignore other messages before peer joins
+                    Some(_) => {} // Ignore unexpected messages
+                }
+            }
+            _ = ping_interval.tick() => {
+                if write_frame(&mut writer, &RelayMessage::Ping).await.is_err() {
+                    let room_guard = room.lock().await;
+                    let disconnect_msg = RelayMessage::PeerDisconnected { peer_id: HOST_PEER_ID };
+                    room_guard.broadcast_to_peers(&disconnect_msg, None).await;
+                    drop(room_guard);
+                    break;
                 }
             }
         }
     }
-
-    // Both connected — run forwarding
-    run_forwarding(
-        &code,
-        &server,
-        &mut reader,
-        &mut writer,
-        &mut rx,
-        &joiner_tx,
-        true,
-    )
-    .await?;
 
     server.remove_room(&code).await;
     info!("Room {} closed (host disconnected)", code);
@@ -268,93 +322,83 @@ async fn handle_joiner(
 ) -> std::io::Result<()> {
     let (tx, mut rx) = mpsc::channel::<RelayMessage>(32);
 
-    let room = match server.join_room(code, tx).await {
-        Ok(room) => room,
+    let (room, peer_id) = match server.join_room(code, tx).await {
+        Ok(result) => result,
         Err(e) => {
             write_frame(&mut writer, &RelayMessage::Error(e)).await?;
             return Ok(());
         }
     };
 
-    info!("Joiner connected to room {}", code);
-    write_frame(&mut writer, &RelayMessage::JoinedRoom).await?;
+    info!("Peer {} connected to room {}", peer_id, code);
 
-    // Get host_tx
+    // Tell the joiner their ID and who's already in the room
+    write_frame(&mut writer, &RelayMessage::JoinedRoom { peer_id }).await?;
+    let existing_peers = {
+        let room_guard = room.lock().await;
+        room_guard.peer_ids()
+    };
+    write_frame(
+        &mut writer,
+        &RelayMessage::PeerList {
+            peers: existing_peers,
+        },
+    )
+    .await?;
+
     let host_tx = {
         let room_guard = room.lock().await;
         room_guard.host_tx.clone()
     };
 
-    run_forwarding(
-        code,
-        &server,
-        &mut reader,
-        &mut writer,
-        &mut rx,
-        &host_tx,
-        false,
-    )
-    .await?;
-
-    server.remove_room(code).await;
-    info!("Room {} closed (joiner disconnected)", code);
-    Ok(())
-}
-
-async fn run_forwarding(
-    code: &str,
-    _server: &Arc<RelayServer>,
-    reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
-    writer: &mut BufWriter<tokio::net::tcp::OwnedWriteHalf>,
-    rx: &mut mpsc::Receiver<RelayMessage>,
-    peer_tx: &mpsc::Sender<RelayMessage>,
-    is_host: bool,
-) -> std::io::Result<()> {
-    let role = if is_host { "host" } else { "joiner" };
     let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
     ping_interval.tick().await; // skip first immediate tick
 
     loop {
         tokio::select! {
-            // Messages from the relay channel (sent by peer)
             msg = rx.recv() => {
                 match msg {
                     Some(relay_msg) => {
-                        write_frame(writer, &relay_msg).await?;
+                        write_frame(&mut writer, &relay_msg).await?;
                     }
-                    None => {
-                        info!("Room {} relay channel closed for {}", code, role);
-                        break;
-                    }
+                    None => break,
                 }
             }
-
-            // Messages from this client's TCP stream
-            msg = read_frame::<ClientMessage, _>(reader) => {
+            msg = read_frame::<ClientMessage, _>(&mut reader) => {
                 match msg? {
-                    Some(ClientMessage::GameData(game_msg)) => {
-                        // Forward to peer
-                        let _ = peer_tx.send(RelayMessage::GameData(game_msg)).await;
+                    Some(ClientMessage::GameData { msg: game_msg, .. }) => {
+                        // Joiner always sends to host
+                        let relay_msg = RelayMessage::GameData { msg: game_msg, from: peer_id };
+                        let _ = host_tx.send(relay_msg).await;
                     }
-                    Some(ClientMessage::Pong) => {}
                     Some(ClientMessage::Disconnect) | None => {
-                        let _ = peer_tx.send(RelayMessage::PeerDisconnected).await;
-                        info!("Room {} {} disconnected", code, role);
+                        // Notify host and remaining peers
+                        let disconnect_msg = RelayMessage::PeerDisconnected { peer_id };
+                        let _ = host_tx.send(disconnect_msg.clone()).await;
+                        let mut room_guard = room.lock().await;
+                        room_guard.remove_peer(peer_id);
+                        room_guard.broadcast_to_peers(&disconnect_msg, None).await;
+                        drop(room_guard);
                         break;
                     }
+                    Some(ClientMessage::Pong) => {}
                     Some(_) => {} // Ignore unexpected messages
                 }
             }
-
-            // Heartbeat ping
             _ = ping_interval.tick() => {
-                if write_frame(writer, &RelayMessage::Ping).await.is_err() {
-                    let _ = peer_tx.send(RelayMessage::PeerDisconnected).await;
+                if write_frame(&mut writer, &RelayMessage::Ping).await.is_err() {
+                    let disconnect_msg = RelayMessage::PeerDisconnected { peer_id };
+                    let _ = host_tx.send(disconnect_msg.clone()).await;
+                    let mut room_guard = room.lock().await;
+                    room_guard.remove_peer(peer_id);
+                    room_guard.broadcast_to_peers(&disconnect_msg, None).await;
+                    drop(room_guard);
                     break;
                 }
             }
         }
     }
 
+    info!("Peer {} disconnected from room {}", peer_id, code);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Extends networked mode from a 1v1 relay to rooms of **1 host + up to 8 joiners**. The host picks any participant (self or a joiner) as the Holder; everyone else is a Viewer. Between rounds the host can rotate the Holder. Spectator mode is removed from the roadmap — multi-viewer support supersedes it.

Full design doc: [`.claude/multi-viewer-plan.md`](.claude/multi-viewer-plan.md)

### Protocol (`crates/protocol`)
- New `PeerId` type (`u8`), with `HOST_PEER_ID = 0`. Joiners get `1, 2, 3, …` assigned by the relay.
- `ClientMessage::GameData` now struct-shaped with `target: Option<PeerId>` — `None` broadcasts, `Some(id)` sends to a specific peer.
- `RelayMessage` variants carry `peer_id` / `from` / `peers`; new `PeerList` lets a joining client learn who's already in the room.
- `GameMessage::RoleAssignment` now carries `holder_id: PeerId` (each peer derives its own role) instead of `host_role: Role`.
- `SwapRoles` → `PickNextHolder` (swapping doesn't generalize to N players).

### Relay (`crates/relay`)
- Rooms hold a `Vec<Peer>` with monotonically-increasing `PeerId` assignment.
- Broadcast vs targeted `GameData` routing based on `target`.
- Only host disconnect destroys the room; joiner disconnect is non-fatal and notifies the rest of the room.
- New `RoomFull` error when a 9th joiner tries to enter.

### Client (`crates/client`)
- `lobby.rs` — host lobby shows a live participant list and a Holder-selection screen populated from that list. Post-game menu: Play Again / Pick Next Holder / Quit.
- `net.rs` — `OutboundMsg::Broadcast` / `OutboundMsg::SendTo` routing; write task fans messages out with the right `target`.
- `game.rs` — input routing by role: Holder processes `UserInput`, Viewers forward `RemoteInput` keyed on the Holder's `PeerId`.
- Joiners now wait for the host's next `RoleAssignment` to signal a new round (avoids a shutdown-path race on intermediate post-game messages).

### Docs / misc
- `README.md`, `CLAUDE.md` rewritten to describe the multi-viewer flow, holder selection, and room capacity.
- `TODO.md` — multi-viewer marked done; spectator mode struck through as superseded.
- `.gitignore` added (target, Cargo backups, OS metadata; Cargo.lock intentionally tracked since this workspace ships binaries).

> Note: the branch currently lands as a single commit (`Status`). History was not rewritten to preserve the already-pushed ref.

## Test plan

- [x] `cargo build --release` clean, `cargo clippy` clean
- [x] Solo game still plays end-to-end (no regression from protocol changes)
- [ ] 1 host + 1 joiner: host as Holder — viewer sees word, host presses y/n
- [ ] 1 host + 1 joiner: joiner as Holder — host sees word, joiner presses y/n
- [ ] 1 host + 3 joiners: host picks a joiner as Holder; all other viewers see the word in sync
- [ ] Pick Next Holder rotates correctly across rounds without reconnecting
- [ ] Play Again keeps the same Holder across rounds without reconnecting
- [ ] Mid-game viewer disconnect: game continues
- [ ] Mid-game holder disconnect: round ends gracefully
- [ ] Host disconnect: room is destroyed, joiners get a clean error
- [ ] 9th joiner receives `RoomFull` error
- [ ] Ctrl+C during any of the above restores the terminal cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)