### PR TITLE
In-TUI end-of-game stats, README refresh, size-optimized release build

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,226 @@
+# Architecture & Technical Reference
+
+Everything under the hood of Guess Up — install layout, release packaging, networked mode, relay server setup, word lists, and the client architecture.
+
+## Install Layout
+
+The `guess_up` binary is self-contained and expects two siblings in its directory:
+
+```
+<install-dir>/
+  guess_up                  # the binary
+  lists/                    # one or more .txt word lists (required)
+    ASOIAF_list.txt
+  .history/                 # created automatically on first game
+    history.json
+  .guess_up_config.json     # created automatically on first save
+```
+
+Drop additional `.txt` files into `lists/` and they show up in the in-game **Word List** picker.
+
+When you run via `cargo run -p guess_up`, the build script copies the repo's `lists/` directory into `target/{debug,release}/` alongside the binary, so everything works out of the box. For release installs, copy the `guess_up` binary together with the `lists/` directory to wherever you want to run it. User config (`.guess_up_config.json`) is created next to the binary on first save.
+
+If `guess_up` is launched without a controlling terminal (e.g. double-clicked from a file manager or a `.desktop` launcher), it detects this and re-launches itself inside a terminal emulator. On Linux it tries `$TERMINAL`, then `xdg-terminal-exec`, then a built-in fallback list (foot, alacritty, kitty, wezterm, gnome-terminal, konsole, xfce4-terminal, tilix, terminator, mate-terminal, lxterminal, xterm). On Windows it tries `wt.exe` then `cmd.exe /c start`. Pass `--no-spawn-terminal` to disable this. If no terminal can be found, a timestamped entry is appended to `.guess_up_launch_error.log` next to the binary.
+
+## Release Packaging
+
+A `Makefile` at the repo root builds distributable archives for Linux and Windows:
+
+```bash
+make release          # build all 4 archives
+make release-linux    # Linux only
+make release-windows  # Windows only
+make help             # list all targets
+```
+
+Output lands in `./dist/`:
+
+| Archive | Contents |
+|---------|----------|
+| `guess_up-<ver>-linux-x86_64.tar.gz`   | `guess_up` + `lists/` + `README.md` |
+| `guess_up-<ver>-windows-x86_64.zip`    | `guess_up.exe` + `lists/` + `README.md` |
+| `relay-<ver>-linux-x86_64.tar.gz`      | `relay` |
+| `relay-<ver>-windows-x86_64.zip`       | `relay.exe` |
+
+Requirements: the two rustup targets (`rustup target add x86_64-unknown-linux-gnu x86_64-pc-windows-gnu`), `x86_64-w64-mingw32-gcc` for Windows cross-linking (configured in `.cargo/config.toml`), plus `tar` and `zip`.
+
+## Networked Mode
+
+Up to 9 players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and up to 8 others **join** with a room code.
+
+### Hosting a Game
+
+Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code, a live participant list, and lets you adjust **Settings** while waiting for players. Once at least one joiner connects, press **Start Game** and pick who will be the **Holder**:
+
+- **Holder** — guesses based on clues and presses `y`/`n` (can be the host or any joiner)
+- **Viewer** — everyone else sees the word on screen and gives verbal clues
+
+After each game, the host sees the end-of-game stats (score, accuracy, pace, missed words) and post-game actions — play again (same holder), pick a new holder, or quit — in a single combined box inside the TUI. The room stays alive across games, so there's no need to reconnect.
+
+### Joining a Game
+
+Select **Join Game** from the main menu, enter the relay server address, then type the room code the host gave you. If the code is wrong, the error appears inline so you can fix it and retry. After the game, the same stats box stays on screen with a "Waiting for host..." footer until the host kicks off the next round.
+
+## Relay Server Setup
+
+The relay is a lightweight TCP server that forwards messages between players. It knows nothing about game logic — all state lives on the host client. Rooms support up to 8 joiners plus the host.
+
+**Build and deploy:**
+
+```bash
+# Build
+cargo build --release -p relay
+
+# Copy to your server
+scp target/release/relay your-server:/usr/local/bin/guess-up-relay
+```
+
+**Run it:**
+
+```bash
+# Simplest form (binds to 0.0.0.0:7878)
+guess-up-relay
+
+# Custom options
+guess-up-relay --bind 0.0.0.0:9000 --max-rooms 50 --room-timeout 1800
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bind` | `0.0.0.0:7878` | Address and port to listen on |
+| `--max-rooms` | `100` | Max concurrent rooms |
+| `--room-timeout` | `3600` | Seconds before an idle room is reaped |
+
+**Open the firewall port:**
+
+```bash
+sudo ufw allow 7878/tcp
+```
+
+**Run as a systemd service (optional):**
+
+Create `/etc/systemd/system/guess-up-relay.service`:
+
+```ini
+[Unit]
+Description=Guess Up Relay Server
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/guess-up-relay --bind 0.0.0.0:7878
+Restart=on-failure
+User=nobody
+Group=nogroup
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now guess-up-relay
+```
+
+**Check logs:**
+
+```bash
+# Direct — tracing output goes to stderr
+RUST_LOG=info guess-up-relay
+
+# Systemd
+journalctl -u guess-up-relay -f
+```
+
+**Verify connectivity from a client machine:**
+
+```bash
+nc -zv your-server 7878
+```
+
+## Menu Navigation
+
+All menus use the same controls:
+
+| Key | Action |
+|-----|--------|
+| `↑` / `k` | Move selection up |
+| `↓` / `j` | Move selection down |
+| `Enter` | Select / confirm |
+| `Esc` / `q` | Go back / quit |
+| `←` / `h` | Decrease value (settings) |
+| `→` / `l` | Increase value (settings) |
+
+In text input fields (server address, room code), type normally. `Enter` confirms, `Esc` cancels.
+
+## Word List Format
+
+The included list (`lists/ASOIAF_list.txt`) has 420+ entries across 25 categories. Custom word files use the same format:
+
+```
+[Category Name]
+Entry One
+Entry Two
+
+[Another Category]
+Entry Three
+```
+
+Lines are trimmed and deduplicated automatically.
+
+## Game Features
+
+- **Interactive TUI menu** — configure all settings from the game, no CLI flags needed
+- **Persistent settings** — saved to `.guess_up_config.json` next to the binary between sessions
+- **Single-keypress input** — `y`/`n`/`q` register instantly, no Enter required
+- **Green/red flash** — visual feedback on correct/pass
+- **Live timer and score** — updated every second
+- **End-of-round summary** — score, accuracy %, pace, and missed words shown inside the TUI for solo, host, and joiner (missed words truncate with `...and N more` when the list is long)
+- **Game history** — results saved to `.history/history.json` in the install directory
+- **Category filtering** — scrollable picker with all 25 categories
+- **Color schemes** — 12 truecolor palettes (Classic, Pastel, Beige, and one for each of the nine ASOIAF great houses — Stark, Lannister, Tyrell, Martell, Greyjoy, Targaryen, Baratheon, Arryn, Tully). House Stark is the default. Pick one from **Settings → Color Scheme** — a live preview panel to the right of the list renders sample UI elements (menu, selected item, summary, error) in the hovered scheme's palette. Press Enter to keep it or Esc to cancel. Your terminal must support 24-bit color.
+- **Multi-player rooms** — 1 host + up to 8 joiners via relay server
+- **Holder selection** — host picks who holds the device from a participant list
+- **Post-game menu** — play again, pick next holder, or quit (room stays alive)
+- **Address validation** — relay addresses validated before connecting
+- **Recent servers** — last 10 relay addresses remembered
+
+## Client Architecture
+
+Cargo workspace with three crates:
+
+```
+crates/
+  protocol/   # shared message types + TCP framing
+  relay/      # standalone relay server binary
+  client/     # the game (solo + networked modes)
+```
+
+Channel-based async with tokio. Three concurrent tasks communicate via `tokio::sync::mpsc`:
+
+```
+Input Task (crossterm EventStream) ---> tx --+
+                                             v
+Timer Task (1s interval ticks)     ---> tx --> Game Loop (tokio::select!) --> Render
+                                             ^
+Network Task (TCP via relay)       ---> tx --+  (networked mode only)
+```
+
+| Module | Responsibility |
+|--------|---------------|
+| `main.rs` | Word loading, startup validation of `lists/`, game runners (solo/host/join), entry point |
+| `config.rs` | `AppConfig` — persistent settings, load/save `.guess_up_config.json` next to the binary |
+| `paths.rs` | Install-layout path resolution (binary dir, `lists/`, `.history/`) — single source of truth |
+| `menu.rs` | TUI menu system — main menu, settings, word list picker, category picker, server connect, room code screens |
+| `types.rs` | Event types, game config, result structs |
+| `game.rs` | Game state, main loop (solo + host), remote game loop |
+| `input.rs` | Async single-keypress input via crossterm |
+| `timer.rs` | 1-second interval ticks, bonus-time support |
+| `render.rs` | Terminal guard (RAII cleanup), all rendering (game + lobby) |
+| `net.rs` | TCP connection to relay, message translation, broadcast/targeted routing |
+| `lobby.rs` | Room setup, multi-player lobby, holder selection, post-game flow |
+| `terminal_spawn.rs` | Detect missing TTY and re-launch inside a terminal emulator (opt-out via `--no-spawn-terminal`) |
+| `theme.rs` | Color scheme table (12 truecolor palettes) and active-scheme cell |
+
+## Roadmap
+
+See [TODO.md](TODO.md) for planned features and improvements.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["crates/protocol", "crates/relay", "crates/client"]
 resolver = "2"
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# Guess Up! - ASOIAF Edition
+# Guess Up! — ASOIAF Edition
 
-A terminal-based "Guess Up" party game themed around A Song of Ice and Fire. Play solo (hold the screen to your forehead while friends give clues) or networked with up to 9 players (1 host + 8 joiners) connected through a relay server.
+A terminal-based "Guess Up" party game, themed around A Song of Ice and Fire. Hold the screen up to your forehead, let your friends shout clues, and press `y` for correct or `n` to pass before the timer runs out. No mouse, no Enter key — just fast, chaotic fun.
 
-Press `y` for correct, `n` to pass — no Enter needed.
+Play solo with a pile of friends in the same room, or get up to 9 people across the internet into the same game through a relay server (1 host + 8 joiners).
 
-## Quickstart
+## Download
 
-Requires [Rust](https://www.rust-lang.org/tools/install). If you run into version issues, run `rustup toolchain install stable`.
+Grab a prebuilt binary from the **[latest release](https://github.com/Tevillo/Guess-Up/releases/latest)** — Linux and Windows archives are available. Unpack, run `guess_up` (or `guess_up.exe`), and you're in.
+
+## Build From Source
+
+If you'd rather build it yourself, you'll need [Rust](https://www.rust-lang.org/tools/install) (any recent stable toolchain — `rustup toolchain install stable` if you hit a version issue).
 
 ```bash
 # Build everything (client + relay server)
@@ -16,236 +20,13 @@ cargo build --release
 cargo run -p guess_up
 ```
 
-An interactive TUI menu lets you configure everything — game time, categories, extra-time mode, relay server address — without any command-line flags. Settings persist between sessions in `.guess_up_config.json` next to the binary.
+That's it. An interactive TUI menu takes over from there — pick a word list, tweak the timer, choose a color scheme, and start playing. Your settings stick around between runs in `.guess_up_config.json` next to the binary.
 
-Press `q` at any time to quit. The terminal always restores cleanly, even on Ctrl+C.
+Press `q` any time to quit. The terminal always restores cleanly, even on Ctrl+C.
 
-If `guess_up` is launched without a controlling terminal (e.g. double-clicked from a file manager or a `.desktop` launcher), it detects this and re-launches itself inside a terminal emulator. On Linux it tries `$TERMINAL`, then `xdg-terminal-exec`, then a built-in fallback list (foot, alacritty, kitty, wezterm, gnome-terminal, konsole, xfce4-terminal, tilix, terminator, mate-terminal, lxterminal, xterm). On Windows it tries `wt.exe` then `cmd.exe /c start`. Pass `--no-spawn-terminal` to disable this. If no terminal can be found, a timestamped entry is appended to `.guess_up_launch_error.log` next to the binary.
+## Technical Details
 
-## Install Layout
-
-The `guess_up` binary is self-contained and expects two siblings in its directory:
-
-```
-<install-dir>/
-  guess_up                  # the binary
-  lists/                    # one or more .txt word lists (required)
-    ASOIAF_list.txt
-  .history/                 # created automatically on first game
-    history.json
-  .guess_up_config.json     # created automatically on first save
-```
-
-Drop additional `.txt` files into `lists/` and they show up in the in-game **Word List** picker.
-
-When you run via `cargo run -p guess_up`, the build script copies the repo's `lists/` directory into `target/{debug,release}/` alongside the binary, so everything works out of the box. For release installs, copy the `guess_up` binary together with the `lists/` directory to wherever you want to run it. User config (`.guess_up_config.json`) is created next to the binary on first save.
-
-## Release Packaging
-
-A `Makefile` at the repo root builds distributable archives for Linux and Windows:
-
-```bash
-make release          # build all 4 archives
-make release-linux    # Linux only
-make release-windows  # Windows only
-make help             # list all targets
-```
-
-Output lands in `./dist/`:
-
-| Archive | Contents |
-|---------|----------|
-| `guess_up-<ver>-linux-x86_64.tar.gz`   | `guess_up` + `lists/` + `README.md` |
-| `guess_up-<ver>-windows-x86_64.zip`    | `guess_up.exe` + `lists/` + `README.md` |
-| `relay-<ver>-linux-x86_64.tar.gz`      | `relay` |
-| `relay-<ver>-windows-x86_64.zip`       | `relay.exe` |
-
-Requirements: the two rustup targets (`rustup target add x86_64-unknown-linux-gnu x86_64-pc-windows-gnu`), `x86_64-w64-mingw32-gcc` for Windows cross-linking (configured in `.cargo/config.toml`), plus `tar` and `zip`.
-
-## Solo Mode
-
-Select **Solo Game** from the main menu. Adjust settings (game time, category, extra-time mode, etc.) via the **Settings** screen before starting.
-
-## Networked Mode
-
-Up to 9 players connect through a relay server. One player **hosts** a room (owns the game state, timer, and word list) and up to 8 others **join** with a room code.
-
-### Hosting a Game
-
-Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code, a live participant list, and lets you adjust **Settings** while waiting for players. Once at least one joiner connects, press **Start Game** and pick who will be the **Holder**:
-
-- **Holder** — guesses based on clues and presses `y`/`n` (can be the host or any joiner)
-- **Viewer** — everyone else sees the word on screen and gives verbal clues
-
-After each game, the host sees the end-of-game stats (score, accuracy, pace, missed words) and post-game actions — play again (same holder), pick a new holder, or quit — in a single combined box inside the TUI. The room stays alive across games, so there's no need to reconnect.
-
-### Joining a Game
-
-Select **Join Game** from the main menu, enter the relay server address, then type the room code the host gave you. If the code is wrong, the error appears inline so you can fix it and retry. After the game, the same stats box stays on screen with a "Waiting for host..." footer until the host kicks off the next round.
-
-### Relay Server Setup
-
-The relay is a lightweight TCP server that forwards messages between players. It knows nothing about game logic — all state lives on the host client. Rooms support up to 8 joiners plus the host.
-
-**Build and deploy:**
-
-```bash
-# Build
-cargo build --release -p relay
-
-# Copy to your server
-scp target/release/relay your-server:/usr/local/bin/guess-up-relay
-```
-
-**Run it:**
-
-```bash
-# Simplest form (binds to 0.0.0.0:7878)
-guess-up-relay
-
-# Custom options
-guess-up-relay --bind 0.0.0.0:9000 --max-rooms 50 --room-timeout 1800
-```
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--bind` | `0.0.0.0:7878` | Address and port to listen on |
-| `--max-rooms` | `100` | Max concurrent rooms |
-| `--room-timeout` | `3600` | Seconds before an idle room is reaped |
-
-**Open the firewall port:**
-
-```bash
-sudo ufw allow 7878/tcp
-```
-
-**Run as a systemd service (optional):**
-
-Create `/etc/systemd/system/guess-up-relay.service`:
-
-```ini
-[Unit]
-Description=Guess Up Relay Server
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/guess-up-relay --bind 0.0.0.0:7878
-Restart=on-failure
-User=nobody
-Group=nogroup
-
-[Install]
-WantedBy=multi-user.target
-```
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now guess-up-relay
-```
-
-**Check logs:**
-
-```bash
-# Direct — tracing output goes to stderr
-RUST_LOG=info guess-up-relay
-
-# Systemd
-journalctl -u guess-up-relay -f
-```
-
-**Verify connectivity from a client machine:**
-
-```bash
-nc -zv your-server 7878
-```
-
-## Menu Navigation
-
-All menus use the same controls:
-
-| Key | Action |
-|-----|--------|
-| `↑` / `k` | Move selection up |
-| `↓` / `j` | Move selection down |
-| `Enter` | Select / confirm |
-| `Esc` / `q` | Go back / quit |
-| `←` / `h` | Decrease value (settings) |
-| `→` / `l` | Increase value (settings) |
-
-In text input fields (server address, room code), type normally. `Enter` confirms, `Esc` cancels.
-
-## Word List Format
-
-The included list (`lists/ASOIAF_list.txt`) has 420+ entries across 25 categories. Custom word files use the same format:
-
-```
-[Category Name]
-Entry One
-Entry Two
-
-[Another Category]
-Entry Three
-```
-
-Lines are trimmed and deduplicated automatically.
-
-## Game Features
-
-- **Interactive TUI menu** — configure all settings from the game, no CLI flags needed
-- **Persistent settings** — saved to `.guess_up_config.json` next to the binary between sessions
-- **Single-keypress input** — `y`/`n`/`q` register instantly, no Enter required
-- **Green/red flash** — visual feedback on correct/pass
-- **Live timer and score** — updated every second
-- **End-of-round summary** — score, accuracy %, pace, and missed words shown inside the TUI for solo, host, and joiner (missed words truncate with `...and N more` when the list is long)
-- **Game history** — results saved to `.history/history.json` in the install directory
-- **Category filtering** — scrollable picker with all 25 categories
-- **Color schemes** — 12 truecolor palettes (Classic, Pastel, Beige, and one for each of the nine ASOIAF great houses — Stark, Lannister, Tyrell, Martell, Greyjoy, Targaryen, Baratheon, Arryn, Tully). House Stark is the default. Pick one from **Settings → Color Scheme** — a live preview panel to the right of the list renders sample UI elements (menu, selected item, summary, error) in the hovered scheme's palette. Press Enter to keep it or Esc to cancel. Your terminal must support 24-bit color.
-- **Multi-player rooms** — 1 host + up to 8 joiners via relay server
-- **Holder selection** — host picks who holds the device from a participant list
-- **Post-game menu** — play again, pick next holder, or quit (room stays alive)
-- **Address validation** — relay addresses validated before connecting
-- **Recent servers** — last 10 relay addresses remembered
-
-## Architecture
-
-Cargo workspace with three crates:
-
-```
-crates/
-  protocol/   # shared message types + TCP framing
-  relay/      # standalone relay server binary
-  client/     # the game (solo + networked modes)
-```
-
-Channel-based async with tokio. Three concurrent tasks communicate via `tokio::sync::mpsc`:
-
-```
-Input Task (crossterm EventStream) ---> tx --+
-                                             v
-Timer Task (1s interval ticks)     ---> tx --> Game Loop (tokio::select!) --> Render
-                                             ^
-Network Task (TCP via relay)       ---> tx --+  (networked mode only)
-```
-
-| Module | Responsibility |
-|--------|---------------|
-| `main.rs` | Word loading, startup validation of `lists/`, game runners (solo/host/join), entry point |
-| `config.rs` | `AppConfig` — persistent settings, load/save `.guess_up_config.json` next to the binary |
-| `paths.rs` | Install-layout path resolution (binary dir, `lists/`, `.history/`) — single source of truth |
-| `menu.rs` | TUI menu system — main menu, settings, word list picker, category picker, server connect, room code screens |
-| `types.rs` | Event types, game config, result structs |
-| `game.rs` | Game state, main loop (solo + host), remote game loop |
-| `input.rs` | Async single-keypress input via crossterm |
-| `timer.rs` | 1-second interval ticks, bonus-time support |
-| `render.rs` | Terminal guard (RAII cleanup), all rendering (game + lobby) |
-| `net.rs` | TCP connection to relay, message translation, broadcast/targeted routing |
-| `lobby.rs` | Room setup, multi-player lobby, holder selection, post-game flow |
-| `terminal_spawn.rs` | Detect missing TTY and re-launch inside a terminal emulator (opt-out via `--no-spawn-terminal`) |
-| `theme.rs` | Color scheme table (13 truecolor palettes) and active-scheme cell |
-
-## Roadmap
-
-See [TODO.md](TODO.md) for planned features and improvements.
+For the full tour — install layout, release packaging, networked play, relay server setup, word list format, menu controls, and client architecture — see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **In-TUI end-of-game stats**: `render::render_game_summary` draws the post-game stats box (score, accuracy, pace, missed words) inside the alt screen for solo, host, and joiner. Callers pass action hints so host sees `[P]/[N]/[Q]`, joiner sees a `Waiting for host…` footer, and solo sees `Press any key to continue…` — all inside the same box as the stats.
- **README refresh**: Rewrote `README.md` as a friendly landing page (what it is → [latest release](https://github.com/Tevillo/Guess-Up/releases/latest) → build from source → pointer to the new technical doc). Moved install layout, release packaging, networked mode, relay setup, menu controls, word list format, features, and the crate/module tour into a new `ARCHITECTURE.md`.
- **Size-optimized release profile**: Added `[profile.release]` to the workspace `Cargo.toml` (`opt-level = "z"`, `lto = true`, `codegen-units = 1`, `strip = true`). Left unwinding in place so `TerminalGuard` still restores the terminal on panic.

## Test plan

- [ ] `cargo build --release` succeeds with the new profile; resulting binary is noticeably smaller than before.
- [ ] Solo game: finish a round → stats box renders inside the alt screen → any key returns to main menu cleanly.
- [ ] Host game (1 host + 1+ joiners): finish a round → stats + `[P]/[N]/[Q]` hints show in one combined box → play-again / pick-next-holder both work without reconnecting.
- [ ] Joiner: finish a round → sees the same stats with `Waiting for host…` footer → next `RoleAssignment` resumes play.
- [ ] Panic path (e.g. `kill -SEGV` or a forced panic in a dev build): terminal restores to a usable state (validates that skipping `panic = "abort"` was the right call).
- [ ] README links resolve: latest-release link, `ARCHITECTURE.md`, `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)