### PR TITLE
v1.1: relay port 3000 default + ASOIAF room codes

### DIFF
--- a/.claude/claude-p2p-plan.md
+++ b/.claude/claude-p2p-plan.md
@@ -141,7 +141,7 @@ A small, stateless (re: game logic) TCP server. ~200-300 lines.
 
 ### Core Logic
 
-1. Listen on configurable `bind` address (default `0.0.0.0:7878`)
+1. Listen on configurable `bind` address (default `0.0.0.0:3000`)
 2. On new TCP connection, read first `ClientMessage`:
    - `CreateRoom` → generate 5-char uppercase room code, store room with host's write channel, respond `RoomCreated { code }`
    - `JoinRoom { code }` → look up room, respond `JoinedRoom` to joiner + `PeerJoined` to host

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ Up to 9 players connect through a relay server. One player **hosts** a room (own
 
 ### Hosting a Game
 
-Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:7878`). The host lobby shows the room code, a live participant list, and lets you adjust **Settings** while waiting for players. Once at least one joiner connects, press **Start Game** and pick who will be the **Holder**:
+Select **Host Game** from the main menu, then enter your relay server address (e.g. `your-server:3000`). The host lobby shows the room code (an ASOIAF name like `HODOR` or `DROGON`), a live participant list, and lets you adjust **Settings** while waiting for players. Once at least one joiner connects, press **Start Game** and pick who will be the **Holder**:
 
 - **Holder** — guesses based on clues and presses `y`/`n` (can be the host or any joiner)
 - **Viewer** — everyone else sees the word on screen and gives verbal clues
@@ -59,7 +59,7 @@ After each game, the host sees the end-of-game stats (score, accuracy, pace, mis
 
 ### Joining a Game
 
-Select **Join Game** from the main menu, enter the relay server address, then type the room code the host gave you. If the code is wrong, the error appears inline so you can fix it and retry. After the game, the same stats box stays on screen with a "Waiting for host..." footer until the host kicks off the next round.
+Select **Join Game** from the main menu, enter the relay server address, then type the room code the host gave you (case doesn't matter — `hodor`, `HODOR`, and `Hodor` all work). If the code is wrong, the error appears inline so you can fix it and retry. After the game, the same stats box stays on screen with a "Waiting for host..." footer until the host kicks off the next round.
 
 ## Relay Server Setup
 
@@ -78,7 +78,7 @@ scp target/release/relay your-server:/usr/local/bin/guess-up-relay
 **Run it:**
 
 ```bash
-# Simplest form (binds to 0.0.0.0:7878)
+# Simplest form (binds to 0.0.0.0:3000)
 guess-up-relay
 
 # Custom options
@@ -87,14 +87,14 @@ guess-up-relay --bind 0.0.0.0:9000 --max-rooms 50 --room-timeout 1800
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--bind` | `0.0.0.0:7878` | Address and port to listen on |
+| `--bind` | `0.0.0.0:3000` | Address and port to listen on |
 | `--max-rooms` | `100` | Max concurrent rooms |
 | `--room-timeout` | `3600` | Seconds before an idle room is reaped |
 
 **Open the firewall port:**
 
 ```bash
-sudo ufw allow 7878/tcp
+sudo ufw allow 3000/tcp
 ```
 
 **Run as a systemd service (optional):**
@@ -107,7 +107,7 @@ Description=Guess Up Relay Server
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/guess-up-relay --bind 0.0.0.0:7878
+ExecStart=/usr/local/bin/guess-up-relay --bind 0.0.0.0:3000
 Restart=on-failure
 User=nobody
 Group=nogroup
@@ -134,7 +134,7 @@ journalctl -u guess-up-relay -f
 **Verify connectivity from a client machine:**
 
 ```bash
-nc -zv your-server 7878
+nc -zv your-server 3000
 ```
 
 ## Menu Navigation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 - **Joiner post-game**: After a game, the joiner waits for the host's next `RoleAssignment` (signaling a new round) rather than intermediate `PlayAgain`/`PickNextHolder` messages. This avoids a race condition where the net read task could consume messages during shutdown.
 - **Menu-driven game dispatch**: `menu_loop` owns the full lifecycle — it runs games internally and loops back to the appropriate screen (server connect, room code) after each game ends, preserving menu state.
 - **Settings persistence**: `AppConfig` is loaded from `.guess_up_config.json` (next to the binary) on startup and saved after each menu exit or game. `#[serde(default)]` ensures forward compatibility. On Windows the file is marked hidden on first create.
-- **Address validation**: Relay server addresses are validated (host:port format, numeric port 1-65535) before connection attempts. Errors display inline in red on the input screen.
+- **Address validation**: Relay server addresses are validated and normalized by `menu::normalize_address` before connection attempts (numeric port 1-65535). If the user omits the port — no colon, or trailing colon with nothing after — the default `DEFAULT_RELAY_PORT` (3000) is appended. Errors display inline in red on the input screen.
 - **Word loading**: Parses `[Category]` headers, trims lines, deduplicates via `HashSet` (case-insensitive).
 - **History**: Saved to `./.history/history.json` (next to the binary) via serde. The directory is auto-created on first save.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ cargo build --release                          # build all crates
 cargo run -p guess_up                          # launches TUI menu
 
 # Relay server
-cargo run -p relay                             # binds to 0.0.0.0:7878
+cargo run -p relay                             # binds to 0.0.0.0:3000
 ```
 
 All game settings (game time, categories, extra-time mode, relay server, etc.) are configured through the interactive TUI menu. Settings persist between sessions in `.guess_up_config.json` next to the binary. No CLI flags needed for the client.
@@ -86,6 +86,7 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 - **Connection recovery**: In networked mode, `NetHandle::shutdown()` recovers the TCP reader/writer from background tasks so the connection can be reused across games without reconnecting. Both host and joiner recover connections after each game for multi-round play.
 - **Host-authoritative model**: The host owns all game state (words, timer, score). Joiners run `run_remote_game` which only renders based on messages received from the host. Input routing depends on role — Viewer processes `RemoteInput` from the holder's `PeerId`, Holder processes `UserInput`. The host picks who the Holder is from a participant list (can be themselves or any joiner).
 - **Multi-viewer rooms**: Rooms support 1 host + up to 8 joiners. The relay server manages a `Vec<Peer>` per room, assigns monotonically increasing PeerIds, and routes messages (broadcast or targeted). Only host disconnect removes the room; joiner disconnect is non-fatal.
+- **Room codes**: Picked from a hardcoded ASOIAF pool in `crates/relay/src/room_codes.rs` (single-word alphabetic entries ≤8 chars, stored uppercase). `RelayServer::pick_code` tries the pool up to `MAX_POOL_ATTEMPTS` (8) times on collision before falling back to the legacy 5-char random A-Z generator. Joins are case-insensitive — incoming `JoinRoom { code }` is uppercased at the protocol boundary in `handle_connection`.
 - **Joiner post-game**: After a game, the joiner waits for the host's next `RoleAssignment` (signaling a new round) rather than intermediate `PlayAgain`/`PickNextHolder` messages. This avoids a race condition where the net read task could consume messages during shutdown.
 - **Menu-driven game dispatch**: `menu_loop` owns the full lifecycle — it runs games internally and loops back to the appropriate screen (server connect, room code) after each game ends, preserving menu state.
 - **Settings persistence**: `AppConfig` is loaded from `.guess_up_config.json` (next to the binary) on startup and saved after each menu exit or game. `#[serde(default)]` ensures forward compatibility. On Windows the file is marked hidden on first create.

--- a/TODO.md
+++ b/TODO.md
@@ -16,8 +16,8 @@
 | ✅ | Add color scheme option — starting schemes: pastel, beige, blue (shipped with 12 schemes: 3 generic + 9 ASOIAF great houses, truecolor) | Medium | v1.0 |
 | ✅ | Show end-of-game stats in post-game lobby for all players (solo + networked) — score, words guessed/skipped visible to host and joiner inside the TUI; replaces the current post-exit print entirely | Medium | v1.0 |
 | ✅ | Spawn a terminal when executable is run outside of one (e.g. double-clicked from file manager) | Medium | v1.0 |
-| ❌ | Change default relay port from 7878 to 3000 — applies to both the relay's bind address and the client's default server address in `AppConfig` | Easy | v1.1 |
-| ❌ | Change room code to a single ASOIAF name (<8 characters) — curate a hardcoded pool from `lists/ASOIAF_list.txt`; pool is assumed to outpace active room count (reroll on collision) | Easy | v1.1 |
+| ✅ | Change default relay port from 7878 to 3000 — applies to both the relay's bind address and the client's default server address in `AppConfig` | Easy | v1.1 |
+| ✅ | Change room code to a single ASOIAF name (<8 characters) — curate a hardcoded pool from `lists/ASOIAF_list.txt`; pool is assumed to outpace active room count (reroll on collision) | Easy | v1.1 |
 | ❌ | One-way magic-bytes + crate-version handshake (client → relay) — client sends magic bytes + `CARGO_PKG_VERSION` as the first frame on connect; relay hard-rejects on wrong magic or version mismatch. No shared secret (protocol sanity only, not access control) | Medium | v1.1 |
 | ❌ | Simplify menu code — extract a shared list-menu abstraction to eliminate duplicated up/down (↑/k, ↓/j) navigation and select/cancel handling across list-style screens in `menu.rs`. Text-input screens (server connect, join room) are excluded and keep their own pattern | Medium | v1.1 |
 | ❌ | Low-time warning — visual cue when timer is running low (e.g. last 10s border turns red or timer text changes color) | Easy | v1.2 |

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -472,26 +472,33 @@ async fn run_word_list_picker(
 
 // ─── Address validation ─────────────────────────────────────────────
 
-fn validate_address(addr: &str) -> Result<(), &'static str> {
+const DEFAULT_RELAY_PORT: u16 = 3000;
+
+/// Validate the address and normalize it to `host:port`. If the user omits
+/// the port (no colon, or trailing colon with nothing after), default to
+/// `DEFAULT_RELAY_PORT`.
+fn normalize_address(addr: &str) -> Result<String, &'static str> {
+    let addr = addr.trim();
     if addr.is_empty() {
         return Err("Address cannot be empty");
     }
-    let Some(colon_pos) = addr.rfind(':') else {
-        return Err("Missing port — use host:port (e.g. 192.168.1.5:3000)");
+    let (host, port_str) = match addr.rfind(':') {
+        Some(pos) => (&addr[..pos], &addr[pos + 1..]),
+        None => (addr, ""),
     };
-    let host = &addr[..colon_pos];
-    let port_str = &addr[colon_pos + 1..];
     if host.is_empty() {
         return Err("Host cannot be empty");
     }
-    if port_str.is_empty() {
-        return Err("Port cannot be empty — use host:port (e.g. server:3000)");
-    }
-    match port_str.parse::<u16>() {
-        Ok(0) => Err("Port must be between 1 and 65535"),
-        Ok(_) => Ok(()),
-        Err(_) => Err("Port must be a number (e.g. 3000)"),
-    }
+    let port: u16 = if port_str.is_empty() {
+        DEFAULT_RELAY_PORT
+    } else {
+        match port_str.parse::<u16>() {
+            Ok(0) => return Err("Port must be between 1 and 65535"),
+            Ok(p) => p,
+            Err(_) => return Err("Port must be a number (e.g. 3000)"),
+        }
+    };
+    Ok(format!("{host}:{port}"))
 }
 
 // ─── Server connect ─────────────────────────────────────────────────
@@ -564,15 +571,12 @@ async fn run_server_connect(
             // If we're editing text input
             if editing && selected == 0 {
                 match key.code {
-                    KeyCode::Enter => {
-                        let addr = input_buf.trim().to_string();
-                        match validate_address(&addr) {
-                            Ok(()) => return ServerConnectResult::Selected(addr),
-                            Err(e) => {
-                                error_msg = Some(e);
-                            }
+                    KeyCode::Enter => match normalize_address(&input_buf) {
+                        Ok(addr) => return ServerConnectResult::Selected(addr),
+                        Err(e) => {
+                            error_msg = Some(e);
                         }
-                    }
+                    },
                     KeyCode::Esc => {
                         editing = false;
                         error_msg = None;

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -477,7 +477,7 @@ fn validate_address(addr: &str) -> Result<(), &'static str> {
         return Err("Address cannot be empty");
     }
     let Some(colon_pos) = addr.rfind(':') else {
-        return Err("Missing port — use host:port (e.g. 192.168.1.5:7878)");
+        return Err("Missing port — use host:port (e.g. 192.168.1.5:3000)");
     };
     let host = &addr[..colon_pos];
     let port_str = &addr[colon_pos + 1..];
@@ -485,12 +485,12 @@ fn validate_address(addr: &str) -> Result<(), &'static str> {
         return Err("Host cannot be empty");
     }
     if port_str.is_empty() {
-        return Err("Port cannot be empty — use host:port (e.g. server:7878)");
+        return Err("Port cannot be empty — use host:port (e.g. server:3000)");
     }
     match port_str.parse::<u16>() {
         Ok(0) => Err("Port must be between 1 and 65535"),
         Ok(_) => Ok(()),
-        Err(_) => Err("Port must be a number (e.g. 7878)"),
+        Err(_) => Err("Port must be a number (e.g. 3000)"),
     }
 }
 

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -1,7 +1,10 @@
+mod room_codes;
+
 use clap::Parser;
 use protocol::{
     read_frame, write_frame, ClientMessage, PeerId, RelayError, RelayMessage, HOST_PEER_ID,
 };
+use room_codes::{MAX_POOL_ATTEMPTS, POOL};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -16,7 +19,7 @@ const MAX_PEERS_PER_ROOM: usize = 8;
 #[command(version, about = "Guess Up relay server")]
 struct Args {
     /// Address to bind to
-    #[arg(long, default_value = "0.0.0.0:7878")]
+    #[arg(long, default_value = "0.0.0.0:3000")]
     bind: String,
 
     /// Maximum number of rooms
@@ -88,10 +91,30 @@ impl RelayServer {
         }
     }
 
-    fn generate_code() -> String {
+    fn generate_random_code() -> String {
         use rand::Rng;
         let mut rng = rand::thread_rng();
         (0..5).map(|_| rng.gen_range(b'A'..=b'Z') as char).collect()
+    }
+
+    /// Pick a fresh code: try the ASOIAF pool up to MAX_POOL_ATTEMPTS times
+    /// before falling back to the random A-Z generator.
+    fn pick_code(rooms: &HashMap<String, Arc<Mutex<Room>>>) -> String {
+        use rand::seq::SliceRandom;
+        let mut rng = rand::thread_rng();
+        for _ in 0..MAX_POOL_ATTEMPTS {
+            if let Some(candidate) = POOL.choose(&mut rng) {
+                if !rooms.contains_key(*candidate) {
+                    return (*candidate).to_string();
+                }
+            }
+        }
+        loop {
+            let candidate = Self::generate_random_code();
+            if !rooms.contains_key(&candidate) {
+                return candidate;
+            }
+        }
     }
 
     async fn create_room(
@@ -105,13 +128,7 @@ impl RelayServer {
         drop(rooms);
 
         let mut rooms = self.rooms.write().await;
-        // Generate a unique code
-        let code = loop {
-            let candidate = Self::generate_code();
-            if !rooms.contains_key(&candidate) {
-                break candidate;
-            }
-        };
+        let code = Self::pick_code(&rooms);
 
         let room = Arc::new(Mutex::new(Room {
             host_tx,
@@ -228,7 +245,10 @@ async fn handle_connection(server: Arc<RelayServer>, stream: TcpStream) -> std::
 
     match first_msg {
         ClientMessage::CreateRoom => handle_host(server, reader, writer).await,
-        ClientMessage::JoinRoom { code } => handle_joiner(server, &code, reader, writer).await,
+        ClientMessage::JoinRoom { code } => {
+            let code = code.to_ascii_uppercase();
+            handle_joiner(server, &code, reader, writer).await
+        }
         _ => {
             write_frame(&mut writer, &RelayMessage::Error(RelayError::InvalidCode)).await?;
             Ok(())

--- a/crates/relay/src/room_codes.rs
+++ b/crates/relay/src/room_codes.rs
@@ -1,0 +1,16 @@
+//! Hardcoded pool of ASOIAF room codes — single-word alphabetic entries ≤8
+//! chars, filtered from `lists/ASOIAF_list.txt` across all categories. Stored
+//! uppercase so they match the case-insensitive lookup path.
+
+pub const POOL: &[&str] = &[
+    "ANGUY", "ASSHAI", "ASTAPOR", "BRAVOS", "BRONN", "CANNIBAL", "CARAXES", "CRASTER", "DAWN",
+    "DORNE", "DROGON", "DUCK", "EGG", "ESSOS", "GENDRY", "GHOST", "GILLY", "GRENN", "HARDHOME",
+    "HODOR", "HOTPIE", "IB", "ICE", "KARHOLD", "LADY", "LEATHERS", "LONGCLAW", "LORATH", "LYS",
+    "MELEYS", "MEREEN", "MOQORRO", "MYR", "NAARTH", "NYMERIA", "OLDTOWN", "OPPO", "ORELL", "PATE",
+    "PENNY", "PENTOS", "POLLIVER", "PYKE", "PYP", "QARTH", "QOHOR", "QUAITHE", "QYBURN", "REEK",
+    "RHAEGAL", "RIVERRUN", "SALTPANS", "SEASMOKE", "SKAGOS", "STARFALL", "SUMMER", "SUNFYRE",
+    "SUNSPEAR", "SYRAX", "THOROS", "TIMETT", "TYROSH", "TYSHA", "VAL", "VALYRIA", "VARYS",
+    "VERMAX", "VHAGAR", "VISERYON", "VOLANTIS", "WESTEROS", "YEEN", "YGRITTE", "YUNKAI",
+];
+
+pub const MAX_POOL_ATTEMPTS: usize = 8;


### PR DESCRIPTION
## Summary

- **Default relay port 7878 → 3000.** Relay's `--bind` default, every doc example (README, CLAUDE.md, ARCHITECTURE.md, .claude plan), and the client's address-field hint text all now use 3000.
- **Room codes come from an ASOIAF pool.** Hardcoded 74-entry pool in `crates/relay/src/room_codes.rs` — single-word alphabetic entries ≤8 chars, filtered from every category in `lists/ASOIAF_list.txt`, stored uppercase. Relay tries the pool up to 8 times on collision, then falls back to the legacy random 5-char A-Z generator. Joins are case-insensitive (incoming \`JoinRoom { code }\` is uppercased at the protocol boundary).
- **Port is optional when connecting.** \`menu::validate_address\` is now \`normalize_address\` — if the user types a host with no port (or a trailing colon with no digits), \`:3000\` is appended automatically. Explicit ports still work as before.

Closes the two "Easy" v1.1 items in TODO.md.

## Test plan

- [x] \`cargo run -p relay\` prints \`Relay listening on 0.0.0.0:3000\`
- [x] \`cargo run -p guess_up\` → Host Game → type just \`127.0.0.1\` (no port) → connects; lobby shows an ASOIAF-style code (e.g. \`HODOR\`, \`DROGON\`)
- [x] Second client → Join Game → \`127.0.0.1\` (no port) + room code in any case (\`hodor\`, \`HODOR\`, \`Hodor\`) → joins
- [x] Invalid inputs still error inline: empty address, \`:3000\` (no host), \`server:0\`, \`server:abc\`, \`server:99999\`
- [x] \`cargo fmt --all --check\` + \`cargo clippy --all-targets --all-features -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)