### PR TITLE
v1.1 — handshake + menu refactor

### DIFF
--- a/.claude/v1.1-remaining-plan.md
+++ b/.claude/v1.1-remaining-plan.md
@@ -1,0 +1,324 @@
+# v1.1 Remaining Items — Plan
+
+Two TODO items remain for v1.1, shipped together on one branch/PR with the v1.1
+version bump:
+
+1. One-way magic-bytes + crate-version handshake (client → relay)
+2. Simplify menu code — shared list-menu abstraction
+
+## Decisions (from clarifying Q&A)
+
+- **Version strictness**: exact match (client `CARGO_PKG_VERSION` must equal the
+  relay's `CARGO_PKG_VERSION`).
+- **Reject UX**: relay sends a structured reason frame before closing; client
+  renders an inline error on the server-connect screen (same slot used by
+  address-validation errors), including both versions so the user can see the
+  drift.
+- **List-menu scope**: abstraction targets the *simple* list pickers. Color
+  scheme picker keeps its bespoke function because of the live preview panel;
+  settings keeps its bespoke handler because of the h/l Left/Right value
+  editing; text-input screens are out of scope per the TODO itself.
+- **Shipping**: one combined branch + PR, includes the v1.1 version bump.
+
+## Branch
+
+`v1.1-handshake-and-menu-refactor` — branched from `main`.
+
+---
+
+## 1. Handshake
+
+### Protocol (`crates/protocol/src/lib.rs`)
+
+Add, at the top of the file:
+
+```rust
+pub const HANDSHAKE_MAGIC: &str = "GUESSUP";
+```
+
+Add two new types (separate from `ClientMessage` / `RelayMessage` — they ride
+over the generic `write_frame` / `read_frame` helpers):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Handshake {
+    pub magic: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HandshakeResponse {
+    Ok,
+    InvalidMagic,
+    VersionMismatch { relay_version: String },
+}
+```
+
+Wire order becomes:
+
+```
+client → relay : Handshake { magic, version }
+relay  → client : HandshakeResponse::Ok | InvalidMagic | VersionMismatch{..}
+[on Ok] client → relay : ClientMessage::CreateRoom | JoinRoom{code}
+... existing flow ...
+```
+
+This requires no changes to framing. Framing is length-prefixed JSON and the
+helpers are already generic over `Serialize/DeserializeOwned`.
+
+### Relay (`crates/relay/src/main.rs`)
+
+In `handle_connection`, before reading the first `ClientMessage`:
+
+1. `read_frame::<Handshake, _>(&mut reader).await?` — treat `None` as EOF, just
+   return.
+2. If `handshake.magic != HANDSHAKE_MAGIC` → write
+   `HandshakeResponse::InvalidMagic`, log a `warn!`, return.
+3. If `handshake.version != env!("CARGO_PKG_VERSION")` → write
+   `HandshakeResponse::VersionMismatch { relay_version: env!(..).to_string() }`,
+   log a `warn!`, return.
+4. Else write `HandshakeResponse::Ok` and fall through to the existing
+   `CreateRoom` / `JoinRoom` branch.
+
+### Client (`crates/client/src/net.rs`)
+
+Introduce a `ConnectError` enum (lives in `net.rs`, exposed to the lobby):
+
+```rust
+#[derive(Debug)]
+pub enum ConnectError {
+    Io(std::io::Error),
+    InvalidMagic,
+    VersionMismatch { client: String, relay: String },
+    HandshakeEof,         // relay closed before sending a response
+    UnexpectedResponse,   // relay sent something unintelligible
+}
+
+impl std::fmt::Display for ConnectError { /* inline reason strings */ }
+impl From<std::io::Error> for ConnectError { /* so `?` still works */ }
+```
+
+Change `NetConnection::connect` to perform the handshake internally:
+
+```rust
+pub async fn connect(addr: &str) -> Result<Self, ConnectError> {
+    let stream = TcpStream::connect(addr).await?;
+    let (reader, writer) = stream.into_split();
+    let mut conn = Self {
+        reader: BufReader::new(reader),
+        writer: BufWriter::new(writer),
+    };
+
+    let hs = Handshake {
+        magic: HANDSHAKE_MAGIC.into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+    };
+    write_frame(&mut conn.writer, &hs).await?;
+
+    match read_frame::<HandshakeResponse, _>(&mut conn.reader).await? {
+        Some(HandshakeResponse::Ok) => Ok(conn),
+        Some(HandshakeResponse::InvalidMagic) => Err(ConnectError::InvalidMagic),
+        Some(HandshakeResponse::VersionMismatch { relay_version }) => {
+            Err(ConnectError::VersionMismatch {
+                client: env!("CARGO_PKG_VERSION").into(),
+                relay: relay_version,
+            })
+        }
+        None => Err(ConnectError::HandshakeEof),
+        _ => Err(ConnectError::UnexpectedResponse),
+    }
+}
+```
+
+### Client surfacing (`crates/client/src/lobby.rs`)
+
+Two callers: `try_host_room` (around line 19) and `try_join_room` (around line
+368). Both map `NetConnection::connect` errors to `io::Result`.
+
+- Rename internal helpers or thread the `ConnectError` through. Simplest change:
+  change their return types to `Result<_, ConnectError>` (ConnectError already
+  holds the io variant), and have the menu layer format the error for display.
+- The menu currently renders a connecting error via text — e.g. `run_join_room`
+  uses `error_msg: Option<String>`. Similarly for host, the host flow that calls
+  `try_host_room` renders failures. Update both call sites to show, e.g.:
+  - `InvalidMagic` → `"relay rejected connection: wrong protocol magic"`
+  - `VersionMismatch { client, relay }` → `"version mismatch: client {client}, relay {relay}"`
+  - `Io(e)` → existing `format!("{}", e)` behaviour
+  - `HandshakeEof` → `"relay closed connection during handshake"`
+  - `UnexpectedResponse` → `"relay sent unexpected handshake response"`
+
+### Docs
+
+- **CLAUDE.md** *Protocol* section: document the new preamble and that the
+  relay rejects on magic or version mismatch.
+- **README.md**: add a one-line note under the relay/client section that the
+  client and relay must be built from the same crate version.
+
+### Manual test
+
+- Build both from `main` with matching versions → play a host+join game
+  round-trip, confirm no regressions.
+- Stamp the client with a fake mismatched `version` (temporarily bump
+  `crates/client/Cargo.toml` to a future version, rebuild) → join attempt
+  fails inline with `version mismatch: client X, relay Y`.
+- Temporarily change `HANDSHAKE_MAGIC` in client only → join fails with
+  `wrong protocol magic`.
+- Revert both test-only edits before committing.
+
+---
+
+## 2. List-menu abstraction
+
+### Goal
+
+Kill duplicated handling of Up / Down / j / k / Enter / Esc / q / Ctrl-C across
+list-style screens in `menu.rs` and `lobby.rs`. The TODO explicitly excludes
+text-input screens.
+
+### In scope
+
+Screens that are just "pick an index from a list":
+- `menu::menu_loop` main menu
+- `menu::run_category_picker`
+- `menu::run_word_list_picker`
+- `lobby::run_holder_picker`
+- `lobby::run_post_game_menu`
+
+### Out of scope (keep custom)
+
+- Settings screen — has h/l Left/Right value cycling, not a pure list.
+- Color scheme picker — needs the side preview panel.
+- Server-connect and Join-room — text-input mixed with list (per TODO).
+
+### Design
+
+New module: `crates/client/src/list_menu.rs`.
+
+Core state + key classification (no async, no I/O):
+
+```rust
+pub struct ListState {
+    pub selected: usize,
+    pub scroll_offset: usize,
+}
+
+impl ListState {
+    pub fn new(initial: usize) -> Self { ... }
+    pub fn on_up(&mut self, len: usize) { ... }        // wraparound
+    pub fn on_down(&mut self, len: usize) { ... }      // wraparound
+    pub fn ensure_visible(&mut self, visible: usize, len: usize) { ... }
+}
+
+pub enum ListKey {
+    Up,
+    Down,
+    Enter,
+    Cancel,
+    Unhandled,
+}
+
+pub fn classify_key(key: &crossterm::event::KeyEvent) -> ListKey {
+    // Up | k       -> Up
+    // Down | j     -> Down
+    // Enter        -> Enter
+    // Esc | q      -> Cancel
+    // Ctrl-C       -> force_exit()   (same as today)
+    // else         -> Unhandled
+}
+```
+
+The keys each screen already handles identically collapse into these. The
+refactor leaves each screen's render call in place — the abstraction is a
+*key-handling* helper, not a full widget loop. That's the minimum change that
+kills the duplication without forcing a new rendering API on top of the
+existing `render::render_menu` / `render::render_category_picker` functions.
+
+Each screen becomes roughly:
+
+```rust
+let mut state = ListState::new(initial_selected);
+loop {
+    state.ensure_visible(visible, items.len());
+    // ... render with state.selected / state.scroll_offset ...
+    let Some(Ok(Event::Key(key))) = reader.next().await else { continue };
+    if key.kind != KeyEventKind::Press { continue }
+    if crate::input::is_ctrl_c(&key) { crate::render::force_exit(); }
+    match list_menu::classify_key(&key) {
+        ListKey::Up     => state.on_up(items.len()),
+        ListKey::Down   => state.on_down(items.len()),
+        ListKey::Enter  => /* screen-specific dispatch */,
+        ListKey::Cancel => return /* screen-specific cancel */,
+        ListKey::Unhandled => {}
+    }
+}
+```
+
+Each refactored screen shrinks by ~15-20 lines of boilerplate.
+
+### Not chosen: full `run_list_menu` async helper
+
+Tempting, but the screens differ in what Enter does (dispatch into game,
+dispatch into sub-menu, return value, toggle edit mode, etc.), and `lobby`
+screens are inside a `tokio::select!` with non-key events. A pure async
+`run_until_selected` helper would force those screens into a shape they don't
+fit. The key-classification approach handles both cases uniformly.
+
+### Wire-up order
+
+1. Add `list_menu` module with `ListState` + `ListKey` + `classify_key`.
+2. Refactor `menu::menu_loop` main menu (smallest test case — 5 items, no
+   scroll).
+3. Refactor `menu::run_category_picker` (adds scroll handling).
+4. Refactor `menu::run_word_list_picker` (identical shape to category).
+5. Refactor `lobby::run_holder_picker` (inside a non-select loop, dispatch
+   per-index).
+6. Refactor `lobby::run_post_game_menu` (same shape).
+7. `cargo build` + `cargo clippy` clean between each refactor step.
+
+---
+
+## 3. Version bump to v1.1.0
+
+Per CLAUDE.md §Release Versioning, completing the last v1.1 item bumps every
+workspace crate to the release version in the same PR. Current state is
+inconsistent (`protocol` 0.1.0, `relay` 0.1.0, `client` 0.2.0) — fixing that
+too.
+
+- `crates/protocol/Cargo.toml`: `version = "1.1.0"`
+- `crates/relay/Cargo.toml`: `version = "1.1.0"`
+- `crates/client/Cargo.toml`: `version = "1.1.0"`
+- Run `cargo build` to refresh `Cargo.lock`; commit the lockfile.
+
+## 4. Docs
+
+- `README.md`: add a "version must match" note near the relay instructions.
+- `CLAUDE.md`:
+  - Protocol section: document Handshake preamble + failure modes.
+  - Client architecture: add `list_menu.rs` to the module table with a short
+    description.
+- `TODO.md`: mark both v1.1 items ✅.
+
+## 5. Acceptance tests (manual)
+
+All of these must pass before the PR goes up:
+
+1. `cargo build --release` — clean.
+2. `cargo clippy` — no warnings.
+3. `cargo fmt -- --check` — clean.
+4. `cargo run -p relay` + `cargo run -p guess_up` solo — unaffected.
+5. Host + joiner matching versions → play a round, Play Again, Pick Next Holder.
+6. Temporarily mismatch client version → join shows inline version mismatch
+   error, no crash; revert after testing.
+7. Main menu nav, category picker, word list picker, holder picker, post-game
+   menu all still navigate with ↑/↓, j/k; Enter/Esc/q/Ctrl-C behaviour
+   unchanged.
+
+## 6. PR
+
+- Title: `v1.1 — handshake + menu refactor`
+- Body:
+  - Summary of the two changes
+  - Note about the protocol preamble being a breaking wire change between
+    client and relay of different versions (by design)
+  - Version bumped to 1.1.0
+  - Test plan checklist from §5 above

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,8 @@ Select **Join Game** from the main menu, enter the relay server address, then ty
 
 The relay is a lightweight TCP server that forwards messages between players. It knows nothing about game logic — all state lives on the host client. Rooms support up to 8 joiners plus the host.
 
+**Version compatibility:** the client and relay must be built from the same workspace version. On connect the client sends a magic-byte + version handshake frame; the relay rejects anything else with an inline error ("wrong protocol magic" or "version mismatch: client X, relay Y"). Upgrade both sides together.
+
 **Build and deploy:**
 
 ```bash
@@ -211,6 +213,7 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 | `config.rs` | `AppConfig` — persistent settings, load/save `.guess_up_config.json` next to the binary |
 | `paths.rs` | Install-layout path resolution (binary dir, `lists/`, `.history/`) — single source of truth |
 | `menu.rs` | TUI menu system — main menu, settings, word list picker, category picker, server connect, room code screens |
+| `list_menu.rs` | Shared `ListState` + `classify_key` helpers used by list-style screens (main menu, pickers, holder/post-game menus) |
 | `types.rs` | Event types, game config, result structs |
 | `game.rs` | Game state, main loop (solo + host), remote game loop |
 | `input.rs` | Async single-keypress input via crossterm |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,13 @@ Network Task (TCP via relay)       ---> tx --+  (networked mode only)
 | `theme.rs` | Color scheme table (12 truecolor palettes — 3 generic + 9 ASOIAF great houses) and the active-scheme `OnceLock<RwLock<&'static ColorScheme>>`. `render.rs` resolves every `SetColors` call through helpers (`fg_on_primary`, `accent_on_primary`, `accent_on_selection`, `error_panel`, `summary_border_colors`, `summary_accent_colors`, `summary_success_colors`) against the active scheme. The color scheme picker (`render_color_scheme_picker`) shows a live preview panel to the right of the list — each hovered scheme is rendered as sample bars (menu text, selected item, title, summary, error) in its own palette while the menu itself stays in the currently-active scheme. Enter commits the hovered scheme via `theme::set_active`; Esc cancels without mutating active state. Flash correct/pass stay hardcoded green/red across all schemes. Requires truecolor (24-bit RGB) terminal. |
 | `paths.rs` | Single source of truth for install-layout paths — `install_dir`, `lists_dir`, `history_dir`, `config_path`, `word_file_path`, `list_available_lists`, `ensure_history_dir`, plus `mark_hidden` (no-op on non-Windows) used to set the hidden attribute on `.history/` and the config file on first create. |
 | `menu.rs` | TUI menu state machine (`menu_loop`), all screens (main, settings, word list picker, category picker, server connect, join room), game dispatch |
+| `list_menu.rs` | Shared helpers for list-style screens — `ListState` (selected cursor + scroll offset with wraparound `on_up`/`on_down` and `ensure_visible`) and `classify_key` (maps Up/k, Down/j, Enter, Esc/q to a `ListKey` enum). Used by main menu, category picker, word list picker, holder picker, and the post-game menu's Esc/q → Quit path. Text-input screens (server connect, join room) and the color-scheme picker keep their bespoke handlers. |
 | `types.rs` | `GameEvent`, `UserAction`, `GameMode`, `GameConfig`, `GameResult`, type aliases |
 | `game.rs` | `GameState`, game loop (`tokio::select!`), Fisher-Yates shuffle, history saving. `run_game` is the host/solo loop, `run_remote_game` is the joiner's display-only loop |
 | `input.rs` | `input_task()` — crossterm `EventStream`, single-keypress in raw mode |
 | `timer.rs` | `timer_task()` — 1s interval ticks, bonus-time channel for extra-time mode |
 | `render.rs` | `TerminalGuard` (RAII cleanup), `MenuItem` enum, menu rendering, game rendering, flash, countdown, lobby screens, `render_game_summary` (in-TUI end-of-game stats box with caller-supplied action hints) |
-| `net.rs` | `NetConnection` (TCP connect/split/reassemble), `NetHandle` (spawn read/write tasks, recoverable shutdown), `OutboundMsg` (Broadcast/SendTo routing) |
+| `net.rs` | `NetConnection` (TCP connect + handshake, split/reassemble), `ConnectError` (IO / InvalidMagic / VersionMismatch / HandshakeEof), `NetHandle` (spawn read/write tasks, recoverable shutdown), `OutboundMsg` (Broadcast/SendTo routing) |
 | `lobby.rs` | Room creation, host lobby (wait for players with live participant list), holder selection (pick any participant), joiner session loop, post-game menu (play again / pick next holder / quit), connection recovery across games |
 | `terminal_spawn.rs` | Detect missing TTY (`IsTerminal` on stdin+stdout) and re-launch the binary inside a terminal emulator. Linux picker: `$TERMINAL` → `xdg-terminal-exec` → built-in fallback list. Windows picker: `wt.exe` → `cmd.exe /c start`. Loop-safe via `GUESS_UP_SPAWNED=1` sentinel. Opt-out with `--no-spawn-terminal`. On total failure, appends a timestamped entry to `<install_dir>/.guess_up_launch_error.log` and exits 1. |
 
@@ -96,7 +97,16 @@ The key invariant is that `input.rs` stays separate from `game.rs` to allow swap
 
 ### Protocol
 
-The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`/`write_frame`, max 64KB). Peers are identified by `PeerId` (u8); host is always `HOST_PEER_ID` (0), joiners get 1, 2, 3, etc. assigned by the relay. Three message layers:
+The `protocol` crate defines length-prefixed JSON framing over TCP (`read_frame`/`write_frame`, max 64KB). Peers are identified by `PeerId` (u8); host is always `HOST_PEER_ID` (0), joiners get 1, 2, 3, etc. assigned by the relay.
+
+**Handshake preamble** (v1.1+): the first frame on every connection is a client-sent `Handshake { magic, version }`. The relay validates both fields before reading any `ClientMessage`:
+- `magic` must equal `HANDSHAKE_MAGIC` (`"GUESSUP"`) — otherwise the relay replies `HandshakeResponse::InvalidMagic` and closes.
+- `version` must exactly equal the relay's `CARGO_PKG_VERSION` — otherwise the relay replies `HandshakeResponse::VersionMismatch { relay_version }` and closes.
+- On success the relay replies `HandshakeResponse::Ok` and the normal `ClientMessage` flow begins.
+
+Client and relay must be built from the same workspace version; the handshake is a protocol-sanity check, not access control. The client surfaces rejection errors inline (e.g. `"version mismatch: client 1.1.0, relay 1.0.0"`).
+
+**Message layers:**
 - **ClientMessage**: client → relay (CreateRoom, JoinRoom, GameData { msg, target }, Disconnect, Pong). `target: None` broadcasts, `target: Some(id)` sends to a specific peer.
 - **RelayMessage**: relay → client (RoomCreated, PeerJoined { peer_id }, JoinedRoom { peer_id }, PeerList { peers }, GameData { msg, from }, PeerDisconnected { peer_id }, Ping)
 - **GameMessage**: peer ↔ peer (forwarded through relay) — RoleAssignment { holder_id }, word updates, timer sync, score, input, post-game actions (PlayAgain, PickNextHolder, QuitSession)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "guess_up"
-version = "0.2.0"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "crossterm",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "protocol"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "relay"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "protocol",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Grab a prebuilt binary from the **[latest release](https://github.com/Tevillo/Gu
 
 Press `q` any time to quit. The terminal always restores cleanly, even on Ctrl+C.
 
+For networked play the `guess_up` client and the `relay` server must be built from the same crate version. The client sends a version handshake on connect; the relay rejects any mismatch with an inline error, so both sides need to be upgraded together.
+
 ---
 ### Build From Source
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,8 +18,8 @@
 | ✅ | Spawn a terminal when executable is run outside of one (e.g. double-clicked from file manager) | Medium | v1.0 |
 | ✅ | Change default relay port from 7878 to 3000 — applies to both the relay's bind address and the client's default server address in `AppConfig` | Easy | v1.1 |
 | ✅ | Change room code to a single ASOIAF name (<8 characters) — curate a hardcoded pool from `lists/ASOIAF_list.txt`; pool is assumed to outpace active room count (reroll on collision) | Easy | v1.1 |
-| ❌ | One-way magic-bytes + crate-version handshake (client → relay) — client sends magic bytes + `CARGO_PKG_VERSION` as the first frame on connect; relay hard-rejects on wrong magic or version mismatch. No shared secret (protocol sanity only, not access control) | Medium | v1.1 |
-| ❌ | Simplify menu code — extract a shared list-menu abstraction to eliminate duplicated up/down (↑/k, ↓/j) navigation and select/cancel handling across list-style screens in `menu.rs`. Text-input screens (server connect, join room) are excluded and keep their own pattern | Medium | v1.1 |
+| ✅ | One-way magic-bytes + crate-version handshake (client → relay) — client sends magic bytes + `CARGO_PKG_VERSION` as the first frame on connect; relay hard-rejects on wrong magic or version mismatch. No shared secret (protocol sanity only, not access control) | Medium | v1.1 |
+| ✅ | Simplify menu code — extract a shared list-menu abstraction to eliminate duplicated up/down (↑/k, ↓/j) navigation and select/cancel handling across list-style screens in `menu.rs`. Text-input screens (server connect, join room) are excluded and keep their own pattern | Medium | v1.1 |
 | ❌ | Low-time warning — visual cue when timer is running low (e.g. last 10s border turns red or timer text changes color) | Easy | v1.2 |
 | ❌ | Custom word list support — allow users to create/import their own themed word lists beyond ASOIAF (partial: drop a `.txt` into `lists/` and it's auto-discovered; no in-app create/import UI yet) | Easy | v1.2 |
 | ❌ | Round-based multiplayer — multiple rounds with automatic role swapping and cumulative scoring | Medium | v1.2 |

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "guess_up"
-version = "0.2.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/client/src/list_menu.rs
+++ b/crates/client/src/list_menu.rs
@@ -1,0 +1,91 @@
+//! Shared helpers for list-style TUI screens.
+//!
+//! All of the "pick an index from a list" screens (main menu, category
+//! picker, word list picker, holder picker, post-game menu) used to carry
+//! identical blocks of up/down/enter/cancel/Ctrl-C handling and scroll
+//! bookkeeping. This module centralises that logic as pure, synchronous
+//! helpers — each screen keeps its own render call and its own Enter/Cancel
+//! dispatch, but routes key events through `classify_key` and tracks its
+//! cursor in a `ListState`.
+//!
+//! Text-input screens (server connect, join room) are out of scope — they
+//! mix character input with list navigation and are better served by their
+//! bespoke handlers.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+/// Cursor + scroll offset for a list-style screen. `selected` is the
+/// absolute index into the underlying items slice; `scroll_offset` is the
+/// index of the first on-screen row. Screens without scrolling can ignore
+/// `scroll_offset`.
+pub struct ListState {
+    pub selected: usize,
+    pub scroll_offset: usize,
+}
+
+impl ListState {
+    pub fn new(initial: usize) -> Self {
+        Self {
+            selected: initial,
+            scroll_offset: 0,
+        }
+    }
+
+    /// Move the cursor up, wrapping to the last item when already at the top.
+    /// `len` is the number of items currently in the list.
+    pub fn on_up(&mut self, len: usize) {
+        if len == 0 {
+            return;
+        }
+        self.selected = self.selected.checked_sub(1).unwrap_or(len - 1);
+    }
+
+    /// Move the cursor down, wrapping to the first item when at the bottom.
+    pub fn on_down(&mut self, len: usize) {
+        if len == 0 {
+            return;
+        }
+        self.selected = (self.selected + 1) % len;
+    }
+
+    /// Adjust `scroll_offset` so that `selected` is within the visible
+    /// window. Safe to call before every render; a no-op when already in
+    /// range.
+    pub fn ensure_visible(&mut self, visible: usize, _len: usize) {
+        if visible == 0 {
+            return;
+        }
+        if self.selected < self.scroll_offset {
+            self.scroll_offset = self.selected;
+        } else if self.selected >= self.scroll_offset + visible {
+            self.scroll_offset = self.selected + 1 - visible;
+        }
+    }
+}
+
+/// Semantic classification of a key event for list-style screens.
+/// `Unhandled` means the caller may apply its own bindings (e.g. the
+/// settings screen's h/l value cycling) before falling through.
+pub enum ListKey {
+    Up,
+    Down,
+    Enter,
+    Cancel,
+    Unhandled,
+}
+
+/// Classify a KeyEvent. `Up/k` → Up, `Down/j` → Down, `Enter` → Enter,
+/// `Esc/q` → Cancel, anything else → Unhandled.
+///
+/// Ctrl-C is intentionally *not* handled here — the caller must check
+/// `input::is_ctrl_c` and invoke `render::force_exit` before classifying,
+/// so force-exit behaviour stays consistent with input-task paths.
+pub fn classify_key(key: &KeyEvent) -> ListKey {
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => ListKey::Up,
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => ListKey::Down,
+        KeyCode::Enter => ListKey::Enter,
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => ListKey::Cancel,
+        _ => ListKey::Unhandled,
+    }
+}

--- a/crates/client/src/lobby.rs
+++ b/crates/client/src/lobby.rs
@@ -1,8 +1,9 @@
 use crate::config::AppConfig;
 use crate::game;
 use crate::input;
+use crate::list_menu::{self, ListKey};
 use crate::menu;
-use crate::net::{self, NetConnection};
+use crate::net::{self, ConnectError, NetConnection};
 use crate::render::{self, MenuItem};
 use crate::timer;
 use crate::types::*;
@@ -13,15 +14,26 @@ use protocol::{
 };
 use std::io::{self, ErrorKind};
 
+/// Map a `ConnectError` to an `io::Error` suitable for the upstream
+/// `io::Result`-returning caller. IO failures keep the "Could not connect to
+/// relay at X:Y:" prefix; handshake rejections pass through their clean
+/// Display format so the user sees exactly why the relay refused them.
+fn connect_error_to_io(addr: &str, err: ConnectError) -> io::Error {
+    match err {
+        ConnectError::Io(io_err) => io::Error::new(
+            ErrorKind::ConnectionRefused,
+            format!("Could not connect to relay at {}: {}", addr, io_err),
+        ),
+        other => io::Error::other(format!("{}", other)),
+    }
+}
+
 // ─── Host session ────────────────────────────────────────────────────
 
 pub async fn run_host_session(relay_addr: &str, app_config: &mut AppConfig) -> io::Result<()> {
-    let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
-        io::Error::new(
-            ErrorKind::ConnectionRefused,
-            format!("Could not connect to relay at {}: {}", relay_addr, e),
-        )
-    })?;
+    let mut conn = NetConnection::connect(relay_addr)
+        .await
+        .map_err(|e| connect_error_to_io(relay_addr, e))?;
 
     // Create room
     conn.send_client_msg(&ClientMessage::CreateRoom).await?;
@@ -366,12 +378,9 @@ async fn run_host_game(
 /// Connect to the relay and join a room. Returns the established connection
 /// and the joiner's peer ID on success.
 pub async fn try_join_room(relay_addr: &str, code: &str) -> io::Result<(NetConnection, PeerId)> {
-    let mut conn = NetConnection::connect(relay_addr).await.map_err(|e| {
-        io::Error::new(
-            ErrorKind::ConnectionRefused,
-            format!("Could not connect to relay at {}: {}", relay_addr, e),
-        )
-    })?;
+    let mut conn = NetConnection::connect(relay_addr)
+        .await
+        .map_err(|e| connect_error_to_io(relay_addr, e))?;
 
     let code_upper = code.to_uppercase();
     conn.send_client_msg(&ClientMessage::JoinRoom {
@@ -607,14 +616,14 @@ async fn select_holder(peers: &[PeerId], app_config: &mut AppConfig) -> PeerId {
         if crate::input::is_ctrl_c(&key) {
             crate::render::force_exit();
         }
-        match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
+        match list_menu::classify_key(&key) {
+            ListKey::Up => {
                 selected = selected.checked_sub(1).unwrap_or(total_selectable - 1);
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            ListKey::Down => {
                 selected = (selected + 1) % total_selectable;
             }
-            KeyCode::Enter => {
+            ListKey::Enter => {
                 if selected == 0 {
                     return HOST_PEER_ID; // Host is holder
                 } else if selected <= peers.len() {
@@ -624,7 +633,8 @@ async fn select_holder(peers: &[PeerId], app_config: &mut AppConfig) -> PeerId {
                     menu::run_settings_inline(app_config, &mut reader).await;
                 }
             }
-            _ => {}
+            // Host can't cancel holder selection — stay in the picker.
+            ListKey::Cancel | ListKey::Unhandled => {}
         }
     }
 }
@@ -668,6 +678,15 @@ async fn run_post_game_menu(
                     if crate::input::is_ctrl_c(&key) {
                         crate::render::force_exit();
                     }
+                    // Esc / q / Q all take the quit path via classify_key's
+                    // Cancel; P/N are hotkeys that fall through Unhandled.
+                    if let ListKey::Cancel = list_menu::classify_key(&key) {
+                        conn.send_client_msg(&ClientMessage::GameData {
+                            msg: GameMessage::QuitSession,
+                            target: None,
+                        }).await?;
+                        return Ok(PostGameAction::Quit);
+                    }
                     match key.code {
                         KeyCode::Char('p') | KeyCode::Char('P') => {
                             conn.send_client_msg(&ClientMessage::GameData {
@@ -682,13 +701,6 @@ async fn run_post_game_menu(
                                 target: None,
                             }).await?;
                             return Ok(PostGameAction::PickNextHolder);
-                        }
-                        KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
-                            conn.send_client_msg(&ClientMessage::GameData {
-                                msg: GameMessage::QuitSession,
-                                target: None,
-                            }).await?;
-                            return Ok(PostGameAction::Quit);
                         }
                         _ => {}
                     }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod game;
 mod input;
+mod list_menu;
 mod lobby;
 mod menu;
 mod net;

--- a/crates/client/src/menu.rs
+++ b/crates/client/src/menu.rs
@@ -1,4 +1,5 @@
 use crate::config::AppConfig;
+use crate::list_menu::{self, ListKey, ListState};
 use crate::render::{self, MenuItem};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures::StreamExt;
@@ -30,7 +31,7 @@ pub async fn menu_loop(config: &mut AppConfig) {
 
         match &screen {
             Screen::Main => {
-                let count = 5; // Solo, Host, Join, Settings, Quit
+                const MAIN_COUNT: usize = 5; // Solo, Host, Join, Settings, Quit
                 let Some(Ok(event)) = reader.next().await else {
                     continue;
                 };
@@ -43,14 +44,14 @@ pub async fn menu_loop(config: &mut AppConfig) {
                 if crate::input::is_ctrl_c(&key) {
                     crate::render::force_exit();
                 }
-                match key.code {
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        selected = selected.checked_sub(1).unwrap_or(count - 1);
+                match list_menu::classify_key(&key) {
+                    ListKey::Up => {
+                        selected = selected.checked_sub(1).unwrap_or(MAIN_COUNT - 1);
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        selected = (selected + 1) % count;
+                    ListKey::Down => {
+                        selected = (selected + 1) % MAIN_COUNT;
                     }
-                    KeyCode::Enter => match selected {
+                    ListKey::Enter => match selected {
                         0 => {
                             guard.take();
                             drop(reader);
@@ -79,8 +80,8 @@ pub async fn menu_loop(config: &mut AppConfig) {
                         4 => return,
                         _ => {}
                     },
-                    KeyCode::Char('q') | KeyCode::Esc => return,
-                    _ => {}
+                    ListKey::Cancel => return,
+                    ListKey::Unhandled => {}
                 }
             }
             Screen::Settings => {
@@ -371,53 +372,43 @@ async fn run_category_picker(
     items.extend(categories.iter().cloned());
 
     // Find initial selection based on current config
-    let mut selected: usize = match &config.category {
+    let initial = match &config.category {
         None => 0,
         Some(cat) => items
             .iter()
             .position(|c| c.eq_ignore_ascii_case(cat))
             .unwrap_or(0),
     };
-    let mut scroll_offset: usize = 0;
+    let mut state = ListState::new(initial);
     let visible = 15usize.min(items.len());
 
     loop {
-        // Adjust scroll to keep selection visible
-        if selected < scroll_offset {
-            scroll_offset = selected;
-        } else if selected >= scroll_offset + visible {
-            scroll_offset = selected - visible + 1;
-        }
+        state.ensure_visible(visible, items.len());
 
         let term_size = render::terminal_size();
-        render::render_category_picker(&items, selected, scroll_offset, term_size);
+        render::render_category_picker(&items, state.selected, state.scroll_offset, term_size);
 
-        if let Some(Ok(Event::Key(key))) = reader.next().await {
-            if key.kind != KeyEventKind::Press {
-                continue;
+        let Some(Ok(Event::Key(key))) = reader.next().await else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        if crate::input::is_ctrl_c(&key) {
+            crate::render::force_exit();
+        }
+        match list_menu::classify_key(&key) {
+            ListKey::Up => state.on_up(items.len()),
+            ListKey::Down => state.on_down(items.len()),
+            ListKey::Enter => {
+                if state.selected == 0 {
+                    return Some(None); // "All"
+                } else {
+                    return Some(Some(items[state.selected].clone()));
+                }
             }
-            if crate::input::is_ctrl_c(&key) {
-                crate::render::force_exit();
-            }
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => {
-                    selected = selected.checked_sub(1).unwrap_or(items.len() - 1);
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    selected = (selected + 1) % items.len();
-                }
-                KeyCode::Enter => {
-                    if selected == 0 {
-                        return Some(None); // "All"
-                    } else {
-                        return Some(Some(items[selected].clone()));
-                    }
-                }
-                KeyCode::Esc | KeyCode::Char('q') => {
-                    return None; // Cancel, keep current
-                }
-                _ => {}
-            }
+            ListKey::Cancel => return None, // Keep current
+            ListKey::Unhandled => {}
         }
     }
 }
@@ -431,41 +422,34 @@ async fn run_word_list_picker(
 ) -> Option<String> {
     let items: Vec<String> = lists.to_vec();
 
-    let mut selected: usize = items
+    let initial = items
         .iter()
         .position(|n| n == &config.word_file)
         .unwrap_or(0);
-    let mut scroll_offset: usize = 0;
+    let mut state = ListState::new(initial);
     let visible = 15usize.min(items.len());
 
     loop {
-        if selected < scroll_offset {
-            scroll_offset = selected;
-        } else if selected >= scroll_offset + visible {
-            scroll_offset = selected - visible + 1;
-        }
+        state.ensure_visible(visible, items.len());
 
         let term_size = render::terminal_size();
-        render::render_word_list_picker(&items, selected, scroll_offset, term_size);
+        render::render_word_list_picker(&items, state.selected, state.scroll_offset, term_size);
 
-        if let Some(Ok(Event::Key(key))) = reader.next().await {
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-            if crate::input::is_ctrl_c(&key) {
-                crate::render::force_exit();
-            }
-            match key.code {
-                KeyCode::Up | KeyCode::Char('k') => {
-                    selected = selected.checked_sub(1).unwrap_or(items.len() - 1);
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    selected = (selected + 1) % items.len();
-                }
-                KeyCode::Enter => return Some(items[selected].clone()),
-                KeyCode::Esc | KeyCode::Char('q') => return None,
-                _ => {}
-            }
+        let Some(Ok(Event::Key(key))) = reader.next().await else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        if crate::input::is_ctrl_c(&key) {
+            crate::render::force_exit();
+        }
+        match list_menu::classify_key(&key) {
+            ListKey::Up => state.on_up(items.len()),
+            ListKey::Down => state.on_down(items.len()),
+            ListKey::Enter => return Some(items[state.selected].clone()),
+            ListKey::Cancel => return None,
+            ListKey::Unhandled => {}
         }
     }
 }

--- a/crates/client/src/net.rs
+++ b/crates/client/src/net.rs
@@ -1,5 +1,8 @@
 use crate::types::*;
-use protocol::{read_frame, write_frame, ClientMessage, GameMessage, PeerId, RelayMessage};
+use protocol::{
+    read_frame, write_frame, ClientMessage, GameMessage, Handshake, HandshakeResponse, PeerId,
+    RelayMessage, HANDSHAKE_MAGIC,
+};
 use tokio::io::{BufReader, BufWriter};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
@@ -7,6 +10,42 @@ use tokio::sync::{mpsc, oneshot};
 
 pub type Reader = BufReader<OwnedReadHalf>;
 pub type Writer = BufWriter<OwnedWriteHalf>;
+
+/// Errors produced by `NetConnection::connect`. Covers both the underlying
+/// TCP/IO failures and the handshake-layer rejections (wrong magic,
+/// version mismatch, malformed/missing response).
+#[derive(Debug)]
+pub enum ConnectError {
+    Io(std::io::Error),
+    InvalidMagic,
+    VersionMismatch { client: String, relay: String },
+    HandshakeEof,
+}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectError::Io(e) => write!(f, "{}", e),
+            ConnectError::InvalidMagic => {
+                write!(f, "relay rejected connection: wrong protocol magic")
+            }
+            ConnectError::VersionMismatch { client, relay } => {
+                write!(f, "version mismatch: client {}, relay {}", client, relay)
+            }
+            ConnectError::HandshakeEof => {
+                write!(f, "relay closed connection during handshake")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConnectError {}
+
+impl From<std::io::Error> for ConnectError {
+    fn from(e: std::io::Error) -> Self {
+        ConnectError::Io(e)
+    }
+}
 
 /// Outbound message from the game loop to the net write task.
 #[derive(Debug, Clone)]
@@ -22,13 +61,32 @@ pub struct NetConnection {
 }
 
 impl NetConnection {
-    pub async fn connect(addr: &str) -> std::io::Result<Self> {
+    pub async fn connect(addr: &str) -> Result<Self, ConnectError> {
         let stream = TcpStream::connect(addr).await?;
         let (reader, writer) = stream.into_split();
-        Ok(Self {
+        let mut conn = Self {
             reader: BufReader::new(reader),
             writer: BufWriter::new(writer),
-        })
+        };
+
+        let client_version = env!("CARGO_PKG_VERSION");
+        let hs = Handshake {
+            magic: HANDSHAKE_MAGIC.to_string(),
+            version: client_version.to_string(),
+        };
+        write_frame(&mut conn.writer, &hs).await?;
+
+        match read_frame::<HandshakeResponse, _>(&mut conn.reader).await? {
+            Some(HandshakeResponse::Ok) => Ok(conn),
+            Some(HandshakeResponse::InvalidMagic) => Err(ConnectError::InvalidMagic),
+            Some(HandshakeResponse::VersionMismatch { relay_version }) => {
+                Err(ConnectError::VersionMismatch {
+                    client: client_version.to_string(),
+                    relay: relay_version,
+                })
+            }
+            None => Err(ConnectError::HandshakeEof),
+        }
     }
 
     pub async fn send_client_msg(&mut self, msg: &ClientMessage) -> std::io::Result<()> {

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -4,10 +4,33 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 // ─── Constants ───────────────────────────────────────────────────────
 const MAX_FRAME_SIZE: u32 = 65_536; // 64KB
 
+/// Magic string sent as the first handshake frame from client to relay.
+/// The relay hard-rejects connections that don't send this exact value.
+pub const HANDSHAKE_MAGIC: &str = "GUESSUP";
+
 // ─── Peer ID ─────────────────────────────────────────────────────────
 
 pub type PeerId = u8;
 pub const HOST_PEER_ID: PeerId = 0;
+
+// ─── Handshake ───────────────────────────────────────────────────────
+
+/// First frame the client sends on connect. The relay validates both the
+/// magic and the exact crate version before accepting further messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Handshake {
+    pub magic: String,
+    pub version: String,
+}
+
+/// Relay's reply to a `Handshake`. Anything other than `Ok` is followed by
+/// the relay closing the connection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HandshakeResponse {
+    Ok,
+    InvalidMagic,
+    VersionMismatch { relay_version: String },
+}
 
 // ─── Framing ─────────────────────────────────────────────────────────
 

--- a/crates/relay/Cargo.toml
+++ b/crates/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -2,7 +2,8 @@ mod room_codes;
 
 use clap::Parser;
 use protocol::{
-    read_frame, write_frame, ClientMessage, PeerId, RelayError, RelayMessage, HOST_PEER_ID,
+    read_frame, write_frame, ClientMessage, Handshake, HandshakeResponse, PeerId, RelayError,
+    RelayMessage, HANDSHAKE_MAGIC, HOST_PEER_ID,
 };
 use room_codes::{MAX_POOL_ATTEMPTS, POOL};
 use std::collections::HashMap;
@@ -236,6 +237,41 @@ async fn handle_connection(server: Arc<RelayServer>, stream: TcpStream) -> std::
     let (reader, writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut writer = BufWriter::new(writer);
+
+    // Handshake: reject on wrong magic or mismatched crate version before any
+    // further traffic. Version check is an exact-match — the relay and client
+    // must be built from the same workspace version.
+    let handshake: Handshake = match read_frame(&mut reader).await? {
+        Some(msg) => msg,
+        None => return Ok(()),
+    };
+
+    if handshake.magic != HANDSHAKE_MAGIC {
+        warn!(
+            "Rejecting connection: invalid handshake magic {:?}",
+            handshake.magic
+        );
+        write_frame(&mut writer, &HandshakeResponse::InvalidMagic).await?;
+        return Ok(());
+    }
+
+    let relay_version = env!("CARGO_PKG_VERSION");
+    if handshake.version != relay_version {
+        warn!(
+            "Rejecting connection: version mismatch (client {}, relay {})",
+            handshake.version, relay_version
+        );
+        write_frame(
+            &mut writer,
+            &HandshakeResponse::VersionMismatch {
+                relay_version: relay_version.to_string(),
+            },
+        )
+        .await?;
+        return Ok(());
+    }
+
+    write_frame(&mut writer, &HandshakeResponse::Ok).await?;
 
     // Read the first message to determine role
     let first_msg: ClientMessage = match read_frame(&mut reader).await? {


### PR DESCRIPTION
## Summary

- **Relay handshake (client → relay):** magic-bytes + crate-version preamble. `HANDSHAKE_MAGIC = "GUESSUP"`; version must exactly match. Relay hard-rejects and closes on mismatch; client surfaces `"relay rejected connection: wrong protocol magic"` or `"version mismatch: client X, relay Y"` inline. **This is a breaking wire change** — client and relay of different versions can no longer talk to each other (by design).
- **Shared list-menu abstraction:** new `crates/client/src/list_menu.rs` with `ListState` (cursor + scroll offset, wraparound `on_up`/`on_down`, `ensure_visible`) and `classify_key` (Up/k, Down/j, Enter, Esc/q/Q → `ListKey`). Main menu, category picker, word list picker, holder picker, and the post-game menu's Esc/q → Quit branch all go through it. Color-scheme picker and text-input screens keep their bespoke handlers.
- **Version bump to 1.1.0:** all three workspace crates (previously at mismatched 0.1.0 / 0.2.0) are now aligned at `1.1.0`; `Cargo.lock` refreshed.

Docs updated: `CLAUDE.md` protocol section documents the handshake preamble + failure modes and module table adds `list_menu.rs` / notes `ConnectError`; `ARCHITECTURE.md` relay section gains a version-compatibility note; `README.md` calls out the matched-version requirement; `TODO.md` marks both v1.1 items ✅.

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Solo game: main menu → Solo → plays full round → summary → any key returns to menu
- [x] Host + joiner at matching 1.1.0 — round-trip a game, Play Again, Pick Next Holder
- [x] Temporarily bump `crates/client/Cargo.toml` to `1.1.1`, rebuild client → join attempt shows inline `"version mismatch: client 1.1.1, relay 1.1.0"`; revert
- [x] Temporarily change `HANDSHAKE_MAGIC` in `crates/protocol/src/lib.rs` (client-only rebuild) → client surfaces `"relay rejected connection: wrong protocol magic"`; revert
- [x] Navigation still works across ↑/↓, j/k, Enter, Esc/q, Ctrl+C on main menu, category picker, word list picker, holder picker, post-game menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)